### PR TITLE
Rework settings footer in editor to bold current link

### DIFF
--- a/websites/recipe-editor/src/app/(editor)/footer.tsx
+++ b/websites/recipe-editor/src/app/(editor)/footer.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const settingsMenu = [
+  { href: "/settings", name: "Settings" },
+  { href: "/menus", name: "Menus" },
+  { href: "/pages", name: "Pages" },
+  { href: "/export", name: "Export" },
+];
+
+export default function SettingsFooter() {
+  const pathname = usePathname();
+  return (
+    <footer className="w-full bg-slate-800 print:hidden border-t border-slate-700">
+      <nav className="flex flex-row flex-wrap justify-center">
+        {settingsMenu.map(({ href, name }) => (
+          <Link
+            key={href}
+            href={href}
+            className={`inline-block p-2 hover:underline${href.startsWith(pathname) ? " font-bold" : ""}`}
+          >
+            {name}
+          </Link>
+        ))}
+      </nav>
+    </footer>
+  );
+}

--- a/websites/recipe-editor/src/app/(editor)/layout.tsx
+++ b/websites/recipe-editor/src/app/(editor)/layout.tsx
@@ -1,27 +1,11 @@
-import Link from "next/link";
 import { ReactNode } from "react";
+import Footer from "./footer";
 
-export default async function SettingsLayout({
-  children,
-}: {
-  children: ReactNode;
-}) {
+export default function SettingsLayout({ children }: { children: ReactNode }) {
   return (
     <>
       {children}
-      <footer className="w-full bg-slate-800 print:hidden border-t border-slate-700">
-        <nav className="flex flex-row flex-wrap justify-center">
-          <Link href="/menus" className="inline-block p-2 hover:underline">
-            Menus
-          </Link>
-          <Link href="/pages" className="inline-block p-2 hover:underline">
-            Pages
-          </Link>
-          <Link href="/export" className="inline-block p-2 hover:underline">
-            Export
-          </Link>
-        </nav>
-      </footer>
+      <Footer />
     </>
   );
 }


### PR DESCRIPTION
![image](https://github.com/rogermparent/content-engine/assets/9111807/9e4dee08-8eac-4f6f-83dc-c0314db3b610)

This PR reworks the settings footer, primarily for the goal of highlighting the current settings page. To do this, we:

- Extract the settings footer from the settings layout into a client component
- Turn the footer links from hard-coded React components into an array of objects that gets mapped
- Compare the current page with the destination url, and bold with tailwind if it's a match (no worries about nesting issues here since none of these pages have subpages)

This implementation might change later when we bring this feature to other headers.