### PR TITLE
Markdown custom controls

### DIFF
--- a/packages/component-library/components/Form/inputs/Markdown/.#index.tsx
+++ b/packages/component-library/components/Form/inputs/Markdown/.#index.tsx
@@ -1,0 +1,1 @@
+roger@tourmaline.34963:1716394838

--- a/packages/component-library/components/Form/inputs/Markdown/.#index.tsx
+++ b/packages/component-library/components/Form/inputs/Markdown/.#index.tsx
@@ -1,1 +1,0 @@
-roger@tourmaline.34963:1716394838

--- a/packages/component-library/components/Form/inputs/Markdown/index.tsx
+++ b/packages/component-library/components/Form/inputs/Markdown/index.tsx
@@ -13,6 +13,313 @@ import clsx from "clsx";
 import StyledMarkdown from "component-library/components/Markdown";
 import { Button } from "component-library/components/Button";
 
+// Interface for the controls component
+interface MarkdownControlsProps {
+  value: string;
+  onChange: (newValue: string) => void;
+  wrapSelection: (
+    prefix: string,
+    suffix: string,
+    setSelection?: boolean,
+  ) => void;
+  selectionRange: { selectionStart: number; selectionEnd: number } | undefined;
+  setSelectionRange: (range: {
+    selectionStart: number;
+    selectionEnd: number;
+  }) => void;
+  getBlockquoteSelection: ({
+    value,
+    selectionStart,
+    selectionEnd,
+  }: {
+    value: string;
+    selectionStart: number;
+    selectionEnd: number;
+  }) => { selectionStart: number; selectionEnd: number };
+}
+
+// Default formatting buttons component
+function DefaultMarkdownControls({
+  value,
+  onChange,
+  wrapSelection,
+  selectionRange,
+  setSelectionRange,
+  getBlockquoteSelection,
+}: MarkdownControlsProps) {
+  // ... (format button and click handlers remain the same)
+}
+
+export function MarkdownInput({
+  name,
+  id = name,
+  defaultValue,
+  onChange,
+  label,
+  errors,
+  controls: CustomControls = DefaultMarkdownControls, // Accept custom controls component
+}: {
+  name?: string;
+  id?: string;
+  label?: string;
+  defaultValue?: string;
+  onChange?: ChangeEventHandler<HTMLTextAreaElement>;
+  errors?: string[];
+  controls?: React.ComponentType<MarkdownControlsProps>; // Prop for custom controls
+}) {
+  const [activeTab, setActiveTab] = useState<"edit" | "preview">("edit");
+  const [value, setValue] = useState(defaultValue || "");
+  const [selectionRange, setSelectionRange] = useState<
+    { selectionStart: number; selectionEnd: number } | undefined
+  >();
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setValue(event.target.value);
+    onChange?.(event);
+  };
+
+  const wrapSelection = (
+    prefix: string,
+    suffix: string,
+    setSelection: boolean = true,
+  ) => {
+    const textArea = textAreaRef.current;
+    if (textArea) {
+      const { selectionStart, selectionEnd } = textArea;
+      const selectedText = value.substring(selectionStart, selectionEnd);
+      const newValue =
+        value.substring(0, selectionStart) +
+        prefix +
+        selectedText +
+        suffix +
+        value.substring(selectionEnd);
+      setValue(newValue);
+      if (setSelection) {
+        setSelectionRange({
+          selectionStart: selectionStart + prefix.length,
+          selectionEnd: selectionEnd + prefix.length,
+        });
+      }
+      onChange?.({
+        target: { value: newValue },
+      } as React.ChangeEvent<HTMLTextAreaElement>);
+    }
+  };
+
+  useEffect(() => {
+    const textArea = textAreaRef.current;
+    if (textArea && selectionRange) {
+      const { selectionStart, selectionEnd } = selectionRange;
+      textArea.focus();
+      textArea.setSelectionRange(selectionStart, selectionEnd);
+    }
+  }, [selectionRange]);
+
+  const handleBoldClick: MouseEventHandler<HTMLButtonElement> = () => {
+    wrapSelection("**", "**");
+  };
+
+  const handleItalicClick: MouseEventHandler<HTMLButtonElement> = () => {
+    wrapSelection("*", "*");
+  };
+
+  const handleCodeClick: MouseEventHandler<HTMLButtonElement> = () => {
+    const textArea = textAreaRef.current;
+    if (textArea) {
+      const { selectionStart, selectionEnd } = textArea;
+      const selectedText = value.substring(selectionStart, selectionEnd);
+
+      if (selectedText.includes("\n")) {
+        // Multiline code block
+        wrapSelection("\n```\n", "\n```\n");
+      } else {
+        // Inline code
+        wrapSelection("`", "`");
+      }
+    }
+  };
+
+  const handleLinkClick: MouseEventHandler<HTMLButtonElement> = () => {
+    const textArea = textAreaRef.current;
+    if (textArea) {
+      const { selectionStart, selectionEnd } = textArea;
+      const selectedText = value.substring(selectionStart, selectionEnd);
+
+      let newSelectionStart = selectionStart + 1; // After the opening bracket
+      let newSelectionEnd;
+
+      if (selectedText.length > 0) {
+        // Text is selected, start selection after selected text and "]("
+        newSelectionStart += selectedText.length + 2;
+        // End selection after "url"
+        newSelectionEnd = newSelectionStart + 3;
+      } else {
+        // No text is selected, place cursor in the label area for typing
+        newSelectionEnd = newSelectionStart;
+      }
+
+      wrapSelection("[", "](url)", false);
+      setSelectionRange({
+        selectionStart: newSelectionStart,
+        selectionEnd: newSelectionEnd,
+      });
+    }
+  };
+
+  function getBlockquoteSelection({
+    value,
+    selectionStart,
+    selectionEnd,
+  }: {
+    value: string;
+    selectionStart: number;
+    selectionEnd: number;
+  }) {
+    if (selectionStart === selectionEnd && selectionEnd !== value.length) {
+      const closestNewlineBefore = value.lastIndexOf(
+        "\n",
+        value[selectionStart] === "\n" ? selectionStart - 1 : selectionStart,
+      );
+      const closestNewlineAfter = value.indexOf("\n", selectionEnd);
+      const lineStart =
+        closestNewlineBefore === -1 ? 0 : closestNewlineBefore + 1;
+      const lineEnd =
+        closestNewlineAfter === -1 ? value.length : closestNewlineAfter;
+      return { selectionStart: lineStart, selectionEnd: lineEnd };
+    } else {
+      return { selectionStart, selectionEnd };
+    }
+  }
+
+  const handleBlockquoteClick: MouseEventHandler<HTMLButtonElement> = () => {
+    const textArea = textAreaRef.current;
+    if (textArea) {
+      const { selectionStart, selectionEnd } = getBlockquoteSelection({
+        selectionStart: textArea.selectionStart,
+        selectionEnd: textArea.selectionEnd,
+        value,
+      });
+
+      const selectedText = value.substring(selectionStart, selectionEnd);
+
+      const selectedLines = selectedText.split("\n");
+
+      const quotedSelectionContent = selectedLines
+        .map((line) => `> ${line}`)
+        .join("\n");
+
+      const characterBeforeSelection = value[selectionStart - 1];
+      const characterTwoBeforeSelection = value[selectionStart - 2];
+      const characterAfterSelection = value[selectionEnd];
+      const characterTwoAfterSelection = value[selectionEnd + 1];
+
+      const quotedSelection = [
+        characterBeforeSelection === "\n" ? "" : "\n",
+        characterTwoBeforeSelection === "\n" ? "" : "\n",
+        quotedSelectionContent,
+        characterAfterSelection === "\n" ? "" : "\n",
+        characterTwoAfterSelection === "\n" ? "" : "\n",
+      ].join("");
+
+      const newValue =
+        value.substring(0, selectionStart) +
+        quotedSelection +
+        value.substring(selectionEnd);
+
+      setValue(newValue);
+
+      if (selectionStart === selectionEnd) {
+        const blockquoteContentIndex =
+          selectionStart + quotedSelection.indexOf("> ") + 2;
+        setSelectionRange({
+          selectionStart: blockquoteContentIndex,
+          selectionEnd: blockquoteContentIndex,
+        });
+      } else {
+        setSelectionRange({
+          selectionStart,
+          selectionEnd: selectionStart + quotedSelection.length,
+        });
+      }
+
+      onChange?.({
+        target: { value: newValue },
+      } as React.ChangeEvent<HTMLTextAreaElement>);
+    }
+  };
+
+  return (
+    <FieldWrapper label={label} id={id}>
+      <Errors errors={errors} />
+      <div className="flex flex-col border rounded">
+        <div className="flex border-b">
+          <Button
+            overrideDefaultStyles={true}
+            className={clsx(
+              activeTab === "edit" ? "bg-blue-500 text-white" : "",
+              "px-4 py-2 rounded-tl",
+            )}
+            onClick={() => setActiveTab("edit")}
+          >
+            Write
+          </Button>
+          <Button
+            overrideDefaultStyles={true}
+            className={clsx(
+              activeTab === "preview" ? "bg-blue-500 text-white" : "",
+              "px-4 py-2 rounded-tr",
+            )}
+            onClick={() => setActiveTab("preview")}
+          >
+            Preview
+          </Button>
+        </div>
+        <div className={activeTab === "edit" ? "" : "hidden"}>
+          <div className="flex gap-2 border-b p-2">
+            <CustomControls
+              value={value}
+              onChange={setValue}
+              wrapSelection={wrapSelection}
+              selectionRange={selectionRange}
+              setSelectionRange={setSelectionRange}
+              getBlockquoteSelection={getBlockquoteSelection}
+            />
+          </div>
+          <textarea
+            name={name}
+            id={id}
+            ref={textAreaRef}
+            className={clsx(baseInputStyle, "px-1 h-40 grow w-full")}
+            value={value}
+            onChange={handleChange}
+          />
+        </div>
+        {activeTab === "preview" ? (
+          <div className={"p-2 markdown-body"}>
+            <StyledMarkdown>{value}</StyledMarkdown>
+          </div>
+        ) : null}
+      </div>
+    </FieldWrapper>
+  );
+}
+
+//"use client";
+
+import {
+  ChangeEventHandler,
+  MouseEventHandler,
+  useState,
+  useRef,
+  useEffect,
+  ReactNode,
+} from "react";
+import { Errors, FieldWrapper, baseInputStyle } from "../..";
+import clsx from "clsx";
+import StyledMarkdown from "component-library/components/Markdown";
+import { Button } from "component-library/components/Button";
+
 function FormatButton({
   children,
   onClick,

--- a/packages/component-library/components/Form/inputs/Markdown/index.tsx
+++ b/packages/component-library/components/Form/inputs/Markdown/index.tsx
@@ -13,10 +13,9 @@ import StyledMarkdown from "component-library/components/Markdown";
 import { Button } from "component-library/components/Button";
 
 export interface MarkdownControlsProps {
-  textAreaRef: RefObject<HTMLTextAreaElement | null>;
+  textArea: HTMLTextAreaElement | null;
   setValue: (value: string) => void;
   setSelectionRange: (range: SelectionRange) => void;
-  onChange?: ChangeEventHandler<HTMLTextAreaElement>;
 }
 
 export interface SelectionRange {
@@ -29,7 +28,6 @@ export interface MarkdownInputProps {
   id?: string;
   label?: string;
   defaultValue?: string;
-  onChange?: ChangeEventHandler<HTMLTextAreaElement>;
   errors?: string[];
   Controls?: (props: MarkdownControlsProps) => ReactNode;
 }
@@ -60,7 +58,6 @@ export const wrapSelection = ({
   setValue,
   reselect = true,
   setSelectionRange,
-  onChange,
 }: {
   prefix: string;
   suffix: string;
@@ -68,7 +65,6 @@ export const wrapSelection = ({
   textArea: HTMLTextAreaElement | null;
   setValue: (value: string) => void;
   setSelectionRange: (range: SelectionRange) => void;
-  onChange?: ChangeEventHandler<HTMLTextAreaElement>;
 }) => {
   if (textArea) {
     const value = textArea.value;
@@ -87,20 +83,14 @@ export const wrapSelection = ({
         selectionEnd: selectionEnd + prefix.length,
       });
     }
-    onChange?.({
-      target: { value: newValue },
-    } as React.ChangeEvent<HTMLTextAreaElement>);
   }
 };
 
 function BoldControl({
-  textAreaRef,
+  textArea,
   setValue,
   setSelectionRange,
-  onChange,
 }: MarkdownControlsProps) {
-  const textArea = textAreaRef.current;
-
   const handleBoldClick: MouseEventHandler<HTMLButtonElement> = () => {
     wrapSelection({
       prefix: "**",
@@ -108,7 +98,6 @@ function BoldControl({
       textArea,
       setValue,
       setSelectionRange,
-      onChange,
     });
   };
 
@@ -120,13 +109,10 @@ function BoldControl({
 }
 
 function ItalicControl({
-  textAreaRef,
+  textArea,
   setValue,
   setSelectionRange,
-  onChange,
 }: MarkdownControlsProps) {
-  const textArea = textAreaRef.current;
-
   const handleItalicClick: MouseEventHandler<HTMLButtonElement> = () => {
     wrapSelection({
       prefix: "*",
@@ -134,7 +120,6 @@ function ItalicControl({
       textArea,
       setValue,
       setSelectionRange,
-      onChange,
     });
   };
 
@@ -146,13 +131,10 @@ function ItalicControl({
 }
 
 function LinkControl({
-  textAreaRef,
+  textArea,
   setValue,
   setSelectionRange,
-  onChange,
 }: MarkdownControlsProps) {
-  const textArea = textAreaRef.current;
-
   const handleLinkClick: MouseEventHandler<HTMLButtonElement> = () => {
     if (textArea) {
       const value = textArea.value;
@@ -178,7 +160,6 @@ function LinkControl({
         textArea,
         setValue,
         setSelectionRange,
-        onChange,
         reselect: false,
       });
       setSelectionRange({
@@ -221,14 +202,11 @@ function getBlockquoteSelection({
 }
 
 function BlockquoteControl({
-  textAreaRef,
+  textArea,
   setValue,
   setSelectionRange,
-  onChange,
 }: MarkdownControlsProps) {
   const handleBlockquoteClick: MouseEventHandler<HTMLButtonElement> = () => {
-    const textArea = textAreaRef.current;
-
     if (textArea) {
       const value = textArea.value;
       const { selectionStart, selectionEnd } = getBlockquoteSelection({
@@ -278,10 +256,6 @@ function BlockquoteControl({
           selectionEnd: selectionStart + quotedSelection.length,
         });
       }
-
-      onChange?.({
-        target: { value: newValue },
-      } as React.ChangeEvent<HTMLTextAreaElement>);
     }
   };
 
@@ -293,14 +267,11 @@ function BlockquoteControl({
 }
 
 function CodeControl({
-  textAreaRef,
+  textArea,
   setValue,
   setSelectionRange,
-  onChange,
 }: MarkdownControlsProps) {
   const handleCodeClick: MouseEventHandler<HTMLButtonElement> = () => {
-    const textArea = textAreaRef.current;
-
     if (textArea) {
       const value = textArea.value;
       const { selectionStart, selectionEnd } = textArea;
@@ -314,7 +285,6 @@ function CodeControl({
           textArea,
           setValue,
           setSelectionRange,
-          onChange,
         });
       } else {
         // Inline code
@@ -324,7 +294,6 @@ function CodeControl({
           textArea,
           setValue,
           setSelectionRange,
-          onChange,
         });
       }
     }
@@ -338,42 +307,36 @@ function CodeControl({
 }
 
 export function DefaultControls({
-  textAreaRef,
+  textArea,
   setValue,
   setSelectionRange,
-  onChange,
 }: MarkdownControlsProps) {
   return (
     <>
       <BoldControl
-        textAreaRef={textAreaRef}
+        textArea={textArea}
         setValue={setValue}
         setSelectionRange={setSelectionRange}
-        onChange={onChange}
       />
       <ItalicControl
-        textAreaRef={textAreaRef}
+        textArea={textArea}
         setValue={setValue}
         setSelectionRange={setSelectionRange}
-        onChange={onChange}
       />
       <CodeControl
-        textAreaRef={textAreaRef}
+        textArea={textArea}
         setValue={setValue}
         setSelectionRange={setSelectionRange}
-        onChange={onChange}
       />
       <LinkControl
-        textAreaRef={textAreaRef}
+        textArea={textArea}
         setValue={setValue}
         setSelectionRange={setSelectionRange}
-        onChange={onChange}
       />
       <BlockquoteControl
-        textAreaRef={textAreaRef}
+        textArea={textArea}
         setValue={setValue}
         setSelectionRange={setSelectionRange}
-        onChange={onChange}
       />
     </>
   );
@@ -383,7 +346,6 @@ export function MarkdownInput({
   name,
   id = name,
   defaultValue,
-  onChange,
   label,
   errors,
   Controls = DefaultControls,
@@ -393,15 +355,9 @@ export function MarkdownInput({
   const [selectionRange, setSelectionRange] = useState<
     SelectionRange | undefined
   >();
-  const textAreaRef = useRef<HTMLTextAreaElement>(null);
-
-  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setValue(event.target.value);
-    onChange?.(event);
-  };
+  const [textArea, setTextArea] = useState<HTMLTextAreaElement | null>(null);
 
   useEffect(() => {
-    const textArea = textAreaRef.current;
     if (textArea && selectionRange) {
       const { selectionStart, selectionEnd } = selectionRange;
       textArea.focus();
@@ -438,19 +394,19 @@ export function MarkdownInput({
         <div className={activeTab === "edit" ? "" : "hidden"}>
           <div className="flex gap-2 border-b p-2">
             <Controls
-              textAreaRef={textAreaRef}
+              textArea={textArea}
               setValue={setValue}
               setSelectionRange={setSelectionRange}
-              onChange={onChange}
             />
           </div>
           <textarea
             name={name}
             id={id}
-            ref={textAreaRef}
+            ref={(el) => {
+              setTextArea(el);
+            }}
             className={clsx(baseInputStyle, "px-1 h-40 grow w-full")}
             value={value}
-            onChange={handleChange}
           />
         </div>
         {activeTab === "preview" ? (

--- a/packages/component-library/components/Form/inputs/Markdown/index.tsx
+++ b/packages/component-library/components/Form/inputs/Markdown/index.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import {
   ChangeEventHandler,
   MouseEventHandler,
@@ -7,318 +5,34 @@ import {
   useRef,
   useEffect,
   ReactNode,
+  RefObject,
 } from "react";
 import { Errors, FieldWrapper, baseInputStyle } from "../..";
 import clsx from "clsx";
 import StyledMarkdown from "component-library/components/Markdown";
 import { Button } from "component-library/components/Button";
 
-// Interface for the controls component
 interface MarkdownControlsProps {
-  value: string;
-  onChange: (newValue: string) => void;
-  wrapSelection: (
-    prefix: string,
-    suffix: string,
-    setSelection?: boolean,
-  ) => void;
-  selectionRange: { selectionStart: number; selectionEnd: number } | undefined;
-  setSelectionRange: (range: {
-    selectionStart: number;
-    selectionEnd: number;
-  }) => void;
-  getBlockquoteSelection: ({
-    value,
-    selectionStart,
-    selectionEnd,
-  }: {
-    value: string;
-    selectionStart: number;
-    selectionEnd: number;
-  }) => { selectionStart: number; selectionEnd: number };
+  textAreaRef: RefObject<HTMLTextAreaElement | null>;
+  setValue: (value: string) => void;
+  setSelectionRange: (range: SelectionRange) => void;
+  onChange?: ChangeEventHandler<HTMLTextAreaElement>;
 }
 
-// Default formatting buttons component
-function DefaultMarkdownControls({
-  value,
-  onChange,
-  wrapSelection,
-  selectionRange,
-  setSelectionRange,
-  getBlockquoteSelection,
-}: MarkdownControlsProps) {
-  // ... (format button and click handlers remain the same)
+interface SelectionRange {
+  selectionStart: number;
+  selectionEnd: number;
 }
 
-export function MarkdownInput({
-  name,
-  id = name,
-  defaultValue,
-  onChange,
-  label,
-  errors,
-  controls: CustomControls = DefaultMarkdownControls, // Accept custom controls component
-}: {
+export interface MarkdownInputProps {
   name?: string;
   id?: string;
   label?: string;
   defaultValue?: string;
   onChange?: ChangeEventHandler<HTMLTextAreaElement>;
   errors?: string[];
-  controls?: React.ComponentType<MarkdownControlsProps>; // Prop for custom controls
-}) {
-  const [activeTab, setActiveTab] = useState<"edit" | "preview">("edit");
-  const [value, setValue] = useState(defaultValue || "");
-  const [selectionRange, setSelectionRange] = useState<
-    { selectionStart: number; selectionEnd: number } | undefined
-  >();
-  const textAreaRef = useRef<HTMLTextAreaElement>(null);
-
-  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setValue(event.target.value);
-    onChange?.(event);
-  };
-
-  const wrapSelection = (
-    prefix: string,
-    suffix: string,
-    setSelection: boolean = true,
-  ) => {
-    const textArea = textAreaRef.current;
-    if (textArea) {
-      const { selectionStart, selectionEnd } = textArea;
-      const selectedText = value.substring(selectionStart, selectionEnd);
-      const newValue =
-        value.substring(0, selectionStart) +
-        prefix +
-        selectedText +
-        suffix +
-        value.substring(selectionEnd);
-      setValue(newValue);
-      if (setSelection) {
-        setSelectionRange({
-          selectionStart: selectionStart + prefix.length,
-          selectionEnd: selectionEnd + prefix.length,
-        });
-      }
-      onChange?.({
-        target: { value: newValue },
-      } as React.ChangeEvent<HTMLTextAreaElement>);
-    }
-  };
-
-  useEffect(() => {
-    const textArea = textAreaRef.current;
-    if (textArea && selectionRange) {
-      const { selectionStart, selectionEnd } = selectionRange;
-      textArea.focus();
-      textArea.setSelectionRange(selectionStart, selectionEnd);
-    }
-  }, [selectionRange]);
-
-  const handleBoldClick: MouseEventHandler<HTMLButtonElement> = () => {
-    wrapSelection("**", "**");
-  };
-
-  const handleItalicClick: MouseEventHandler<HTMLButtonElement> = () => {
-    wrapSelection("*", "*");
-  };
-
-  const handleCodeClick: MouseEventHandler<HTMLButtonElement> = () => {
-    const textArea = textAreaRef.current;
-    if (textArea) {
-      const { selectionStart, selectionEnd } = textArea;
-      const selectedText = value.substring(selectionStart, selectionEnd);
-
-      if (selectedText.includes("\n")) {
-        // Multiline code block
-        wrapSelection("\n```\n", "\n```\n");
-      } else {
-        // Inline code
-        wrapSelection("`", "`");
-      }
-    }
-  };
-
-  const handleLinkClick: MouseEventHandler<HTMLButtonElement> = () => {
-    const textArea = textAreaRef.current;
-    if (textArea) {
-      const { selectionStart, selectionEnd } = textArea;
-      const selectedText = value.substring(selectionStart, selectionEnd);
-
-      let newSelectionStart = selectionStart + 1; // After the opening bracket
-      let newSelectionEnd;
-
-      if (selectedText.length > 0) {
-        // Text is selected, start selection after selected text and "]("
-        newSelectionStart += selectedText.length + 2;
-        // End selection after "url"
-        newSelectionEnd = newSelectionStart + 3;
-      } else {
-        // No text is selected, place cursor in the label area for typing
-        newSelectionEnd = newSelectionStart;
-      }
-
-      wrapSelection("[", "](url)", false);
-      setSelectionRange({
-        selectionStart: newSelectionStart,
-        selectionEnd: newSelectionEnd,
-      });
-    }
-  };
-
-  function getBlockquoteSelection({
-    value,
-    selectionStart,
-    selectionEnd,
-  }: {
-    value: string;
-    selectionStart: number;
-    selectionEnd: number;
-  }) {
-    if (selectionStart === selectionEnd && selectionEnd !== value.length) {
-      const closestNewlineBefore = value.lastIndexOf(
-        "\n",
-        value[selectionStart] === "\n" ? selectionStart - 1 : selectionStart,
-      );
-      const closestNewlineAfter = value.indexOf("\n", selectionEnd);
-      const lineStart =
-        closestNewlineBefore === -1 ? 0 : closestNewlineBefore + 1;
-      const lineEnd =
-        closestNewlineAfter === -1 ? value.length : closestNewlineAfter;
-      return { selectionStart: lineStart, selectionEnd: lineEnd };
-    } else {
-      return { selectionStart, selectionEnd };
-    }
-  }
-
-  const handleBlockquoteClick: MouseEventHandler<HTMLButtonElement> = () => {
-    const textArea = textAreaRef.current;
-    if (textArea) {
-      const { selectionStart, selectionEnd } = getBlockquoteSelection({
-        selectionStart: textArea.selectionStart,
-        selectionEnd: textArea.selectionEnd,
-        value,
-      });
-
-      const selectedText = value.substring(selectionStart, selectionEnd);
-
-      const selectedLines = selectedText.split("\n");
-
-      const quotedSelectionContent = selectedLines
-        .map((line) => `> ${line}`)
-        .join("\n");
-
-      const characterBeforeSelection = value[selectionStart - 1];
-      const characterTwoBeforeSelection = value[selectionStart - 2];
-      const characterAfterSelection = value[selectionEnd];
-      const characterTwoAfterSelection = value[selectionEnd + 1];
-
-      const quotedSelection = [
-        characterBeforeSelection === "\n" ? "" : "\n",
-        characterTwoBeforeSelection === "\n" ? "" : "\n",
-        quotedSelectionContent,
-        characterAfterSelection === "\n" ? "" : "\n",
-        characterTwoAfterSelection === "\n" ? "" : "\n",
-      ].join("");
-
-      const newValue =
-        value.substring(0, selectionStart) +
-        quotedSelection +
-        value.substring(selectionEnd);
-
-      setValue(newValue);
-
-      if (selectionStart === selectionEnd) {
-        const blockquoteContentIndex =
-          selectionStart + quotedSelection.indexOf("> ") + 2;
-        setSelectionRange({
-          selectionStart: blockquoteContentIndex,
-          selectionEnd: blockquoteContentIndex,
-        });
-      } else {
-        setSelectionRange({
-          selectionStart,
-          selectionEnd: selectionStart + quotedSelection.length,
-        });
-      }
-
-      onChange?.({
-        target: { value: newValue },
-      } as React.ChangeEvent<HTMLTextAreaElement>);
-    }
-  };
-
-  return (
-    <FieldWrapper label={label} id={id}>
-      <Errors errors={errors} />
-      <div className="flex flex-col border rounded">
-        <div className="flex border-b">
-          <Button
-            overrideDefaultStyles={true}
-            className={clsx(
-              activeTab === "edit" ? "bg-blue-500 text-white" : "",
-              "px-4 py-2 rounded-tl",
-            )}
-            onClick={() => setActiveTab("edit")}
-          >
-            Write
-          </Button>
-          <Button
-            overrideDefaultStyles={true}
-            className={clsx(
-              activeTab === "preview" ? "bg-blue-500 text-white" : "",
-              "px-4 py-2 rounded-tr",
-            )}
-            onClick={() => setActiveTab("preview")}
-          >
-            Preview
-          </Button>
-        </div>
-        <div className={activeTab === "edit" ? "" : "hidden"}>
-          <div className="flex gap-2 border-b p-2">
-            <CustomControls
-              value={value}
-              onChange={setValue}
-              wrapSelection={wrapSelection}
-              selectionRange={selectionRange}
-              setSelectionRange={setSelectionRange}
-              getBlockquoteSelection={getBlockquoteSelection}
-            />
-          </div>
-          <textarea
-            name={name}
-            id={id}
-            ref={textAreaRef}
-            className={clsx(baseInputStyle, "px-1 h-40 grow w-full")}
-            value={value}
-            onChange={handleChange}
-          />
-        </div>
-        {activeTab === "preview" ? (
-          <div className={"p-2 markdown-body"}>
-            <StyledMarkdown>{value}</StyledMarkdown>
-          </div>
-        ) : null}
-      </div>
-    </FieldWrapper>
-  );
+  Controls?: (props: MarkdownControlsProps) => ReactNode;
 }
-
-//"use client";
-
-import {
-  ChangeEventHandler,
-  MouseEventHandler,
-  useState,
-  useRef,
-  useEffect,
-  ReactNode,
-} from "react";
-import { Errors, FieldWrapper, baseInputStyle } from "../..";
-import clsx from "clsx";
-import StyledMarkdown from "component-library/components/Markdown";
-import { Button } from "component-library/components/Button";
 
 function FormatButton({
   children,
@@ -339,97 +53,109 @@ function FormatButton({
   );
 }
 
-export function MarkdownInput({
-  name,
-  id = name,
-  defaultValue,
+const wrapSelection = ({
+  prefix,
+  suffix,
+  textArea,
+  setValue,
+  reselect = true,
+  setSelectionRange,
   onChange,
-  label,
-  errors,
 }: {
-  name?: string;
-  id?: string;
-  label?: string;
-  defaultValue?: string;
+  prefix: string;
+  suffix: string;
+  reselect?: boolean;
+  textArea: HTMLTextAreaElement | null;
+  setValue: (value: string) => void;
+  setSelectionRange: (range: SelectionRange) => void;
   onChange?: ChangeEventHandler<HTMLTextAreaElement>;
-  errors?: string[];
-}) {
-  const [activeTab, setActiveTab] = useState<"edit" | "preview">("edit");
-  const [value, setValue] = useState(defaultValue || "");
-  const [selectionRange, setSelectionRange] = useState<
-    { selectionStart: number; selectionEnd: number } | undefined
-  >();
-  const textAreaRef = useRef<HTMLTextAreaElement>(null);
-
-  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setValue(event.target.value);
-    onChange?.(event);
-  };
-
-  const wrapSelection = (
-    prefix: string,
-    suffix: string,
-    setSelection: boolean = true,
-  ) => {
-    const textArea = textAreaRef.current;
-    if (textArea) {
-      const { selectionStart, selectionEnd } = textArea;
-      const selectedText = value.substring(selectionStart, selectionEnd);
-      const newValue =
-        value.substring(0, selectionStart) +
-        prefix +
-        selectedText +
-        suffix +
-        value.substring(selectionEnd);
-      setValue(newValue);
-      if (setSelection) {
-        setSelectionRange({
-          selectionStart: selectionStart + prefix.length,
-          selectionEnd: selectionEnd + prefix.length,
-        });
-      }
-      onChange?.({
-        target: { value: newValue },
-      } as React.ChangeEvent<HTMLTextAreaElement>);
+}) => {
+  if (textArea) {
+    const value = textArea.value;
+    const { selectionStart, selectionEnd } = textArea;
+    const selectedText = value.substring(selectionStart, selectionEnd);
+    const newValue =
+      value.substring(0, selectionStart) +
+      prefix +
+      selectedText +
+      suffix +
+      value.substring(selectionEnd);
+    setValue(newValue);
+    if (reselect) {
+      setSelectionRange({
+        selectionStart: selectionStart + prefix.length,
+        selectionEnd: selectionEnd + prefix.length,
+      });
     }
-  };
+    onChange?.({
+      target: { value: newValue },
+    } as React.ChangeEvent<HTMLTextAreaElement>);
+  }
+};
 
-  useEffect(() => {
-    const textArea = textAreaRef.current;
-    if (textArea && selectionRange) {
-      const { selectionStart, selectionEnd } = selectionRange;
-      textArea.focus();
-      textArea.setSelectionRange(selectionStart, selectionEnd);
-    }
-  }, [selectionRange]);
+function BoldControl({
+  textAreaRef,
+  setValue,
+  setSelectionRange,
+  onChange,
+}: MarkdownControlsProps) {
+  const textArea = textAreaRef.current;
 
   const handleBoldClick: MouseEventHandler<HTMLButtonElement> = () => {
-    wrapSelection("**", "**");
+    wrapSelection({
+      prefix: "**",
+      suffix: "**",
+      textArea,
+      setValue,
+      setSelectionRange,
+      onChange,
+    });
   };
+
+  return (
+    <FormatButton onClick={handleBoldClick}>
+      <span className="font-bold">B</span>
+    </FormatButton>
+  );
+}
+
+function ItalicControl({
+  textAreaRef,
+  setValue,
+  setSelectionRange,
+  onChange,
+}: MarkdownControlsProps) {
+  const textArea = textAreaRef.current;
 
   const handleItalicClick: MouseEventHandler<HTMLButtonElement> = () => {
-    wrapSelection("*", "*");
+    wrapSelection({
+      prefix: "*",
+      suffix: "*",
+      textArea,
+      setValue,
+      setSelectionRange,
+      onChange,
+    });
   };
 
-  const handleCodeClick: MouseEventHandler<HTMLButtonElement> = () => {
-    const textArea = textAreaRef.current;
-    if (textArea) {
-      const { selectionStart, selectionEnd } = textArea;
-      const selectedText = value.substring(selectionStart, selectionEnd);
+  return (
+    <FormatButton onClick={handleItalicClick}>
+      <span className="italic">I</span>
+    </FormatButton>
+  );
+}
 
-      if (selectedText.includes("\n")) {
-        // Multiline code block
-        wrapSelection("\n```\n", "\n```\n");
-      } else {
-        // Inline code
-        wrapSelection("`", "`");
-      }
-    }
-  };
+function LinkControl({
+  textAreaRef,
+  setValue,
+  setSelectionRange,
+  onChange,
+}: MarkdownControlsProps) {
+  const textArea = textAreaRef.current;
 
   const handleLinkClick: MouseEventHandler<HTMLButtonElement> = () => {
-    const textArea = textAreaRef.current;
     if (textArea) {
+      const value = textArea.value;
       const { selectionStart, selectionEnd } = textArea;
       const selectedText = value.substring(selectionStart, selectionEnd);
 
@@ -446,7 +172,15 @@ export function MarkdownInput({
         newSelectionEnd = newSelectionStart;
       }
 
-      wrapSelection("[", "](url)", false);
+      wrapSelection({
+        prefix: "[",
+        suffix: "](url)",
+        textArea,
+        setValue,
+        setSelectionRange,
+        onChange,
+        reselect: false,
+      });
       setSelectionRange({
         selectionStart: newSelectionStart,
         selectionEnd: newSelectionEnd,
@@ -454,34 +188,49 @@ export function MarkdownInput({
     }
   };
 
-  function getBlockquoteSelection({
-    value,
-    selectionStart,
-    selectionEnd,
-  }: {
-    value: string;
-    selectionStart: number;
-    selectionEnd: number;
-  }) {
-    if (selectionStart === selectionEnd && selectionEnd !== value.length) {
-      const closestNewlineBefore = value.lastIndexOf(
-        "\n",
-        value[selectionStart] === "\n" ? selectionStart - 1 : selectionStart,
-      );
-      const closestNewlineAfter = value.indexOf("\n", selectionEnd);
-      const lineStart =
-        closestNewlineBefore === -1 ? 0 : closestNewlineBefore + 1;
-      const lineEnd =
-        closestNewlineAfter === -1 ? value.length : closestNewlineAfter;
-      return { selectionStart: lineStart, selectionEnd: lineEnd };
-    } else {
-      return { selectionStart, selectionEnd };
-    }
-  }
+  return (
+    <FormatButton onClick={handleLinkClick}>
+      <span className="text-xs">🔗</span>
+    </FormatButton>
+  );
+}
 
+function getBlockquoteSelection({
+  value,
+  selectionStart,
+  selectionEnd,
+}: {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+}) {
+  if (selectionStart === selectionEnd && selectionEnd !== value.length) {
+    const closestNewlineBefore = value.lastIndexOf(
+      "\n",
+      value[selectionStart] === "\n" ? selectionStart - 1 : selectionStart,
+    );
+    const closestNewlineAfter = value.indexOf("\n", selectionEnd);
+    const lineStart =
+      closestNewlineBefore === -1 ? 0 : closestNewlineBefore + 1;
+    const lineEnd =
+      closestNewlineAfter === -1 ? value.length : closestNewlineAfter;
+    return { selectionStart: lineStart, selectionEnd: lineEnd };
+  } else {
+    return { selectionStart, selectionEnd };
+  }
+}
+
+function BlockquoteControl({
+  textAreaRef,
+  setValue,
+  setSelectionRange,
+  onChange,
+}: MarkdownControlsProps) {
   const handleBlockquoteClick: MouseEventHandler<HTMLButtonElement> = () => {
     const textArea = textAreaRef.current;
+
     if (textArea) {
+      const value = textArea.value;
       const { selectionStart, selectionEnd } = getBlockquoteSelection({
         selectionStart: textArea.selectionStart,
         selectionEnd: textArea.selectionEnd,
@@ -537,6 +286,130 @@ export function MarkdownInput({
   };
 
   return (
+    <FormatButton onClick={handleBlockquoteClick}>
+      <span className="text-xs font-bold">&ldquo;</span>
+    </FormatButton>
+  );
+}
+
+function CodeControl({
+  textAreaRef,
+  setValue,
+  setSelectionRange,
+  onChange,
+}: MarkdownControlsProps) {
+  const handleCodeClick: MouseEventHandler<HTMLButtonElement> = () => {
+    const textArea = textAreaRef.current;
+
+    if (textArea) {
+      const value = textArea.value;
+      const { selectionStart, selectionEnd } = textArea;
+      const selectedText = value.substring(selectionStart, selectionEnd);
+
+      if (selectedText.includes("\n")) {
+        // Multiline code block
+        wrapSelection({
+          prefix: "\n```\n",
+          suffix: "\n```\n",
+          textArea,
+          setValue,
+          setSelectionRange,
+          onChange,
+        });
+      } else {
+        // Inline code
+        wrapSelection({
+          prefix: "`",
+          suffix: "`",
+          textArea,
+          setValue,
+          setSelectionRange,
+          onChange,
+        });
+      }
+    }
+  };
+
+  return (
+    <FormatButton onClick={handleCodeClick}>
+      <span className="font-mono text-xs">{"</>"}</span>
+    </FormatButton>
+  );
+}
+
+export function DefaultControls({
+  textAreaRef,
+  setValue,
+  setSelectionRange,
+  onChange,
+}: MarkdownControlsProps) {
+  return (
+    <>
+      <BoldControl
+        textAreaRef={textAreaRef}
+        setValue={setValue}
+        setSelectionRange={setSelectionRange}
+        onChange={onChange}
+      />
+      <ItalicControl
+        textAreaRef={textAreaRef}
+        setValue={setValue}
+        setSelectionRange={setSelectionRange}
+        onChange={onChange}
+      />
+      <CodeControl
+        textAreaRef={textAreaRef}
+        setValue={setValue}
+        setSelectionRange={setSelectionRange}
+        onChange={onChange}
+      />
+      <LinkControl
+        textAreaRef={textAreaRef}
+        setValue={setValue}
+        setSelectionRange={setSelectionRange}
+        onChange={onChange}
+      />
+      <BlockquoteControl
+        textAreaRef={textAreaRef}
+        setValue={setValue}
+        setSelectionRange={setSelectionRange}
+        onChange={onChange}
+      />
+    </>
+  );
+}
+
+export function MarkdownInput({
+  name,
+  id = name,
+  defaultValue,
+  onChange,
+  label,
+  errors,
+  Controls = DefaultControls,
+}: MarkdownInputProps) {
+  const [activeTab, setActiveTab] = useState<"edit" | "preview">("edit");
+  const [value, setValue] = useState(defaultValue || "");
+  const [selectionRange, setSelectionRange] = useState<
+    SelectionRange | undefined
+  >();
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setValue(event.target.value);
+    onChange?.(event);
+  };
+
+  useEffect(() => {
+    const textArea = textAreaRef.current;
+    if (textArea && selectionRange) {
+      const { selectionStart, selectionEnd } = selectionRange;
+      textArea.focus();
+      textArea.setSelectionRange(selectionStart, selectionEnd);
+    }
+  }, [selectionRange]);
+
+  return (
     <FieldWrapper label={label} id={id}>
       <Errors errors={errors} />
       <div className="flex flex-col border rounded">
@@ -564,21 +437,12 @@ export function MarkdownInput({
         </div>
         <div className={activeTab === "edit" ? "" : "hidden"}>
           <div className="flex gap-2 border-b p-2">
-            <FormatButton onClick={handleBoldClick}>
-              <span className="font-bold">B</span>
-            </FormatButton>
-            <FormatButton onClick={handleItalicClick}>
-              <span className="italic">I</span>
-            </FormatButton>
-            <FormatButton onClick={handleCodeClick}>
-              <span className="font-mono text-xs">{"</>"}</span>
-            </FormatButton>
-            <FormatButton onClick={handleLinkClick}>
-              <span className="text-xs">🔗</span>
-            </FormatButton>
-            <FormatButton onClick={handleBlockquoteClick}>
-              <span className="text-xs font-bold">&ldquo;</span>
-            </FormatButton>
+            <Controls
+              textAreaRef={textAreaRef}
+              setValue={setValue}
+              setSelectionRange={setSelectionRange}
+              onChange={onChange}
+            />
           </div>
           <textarea
             name={name}

--- a/packages/component-library/components/Form/inputs/Markdown/index.tsx
+++ b/packages/component-library/components/Form/inputs/Markdown/index.tsx
@@ -12,14 +12,14 @@ import clsx from "clsx";
 import StyledMarkdown from "component-library/components/Markdown";
 import { Button } from "component-library/components/Button";
 
-interface MarkdownControlsProps {
+export interface MarkdownControlsProps {
   textAreaRef: RefObject<HTMLTextAreaElement | null>;
   setValue: (value: string) => void;
   setSelectionRange: (range: SelectionRange) => void;
   onChange?: ChangeEventHandler<HTMLTextAreaElement>;
 }
 
-interface SelectionRange {
+export interface SelectionRange {
   selectionStart: number;
   selectionEnd: number;
 }
@@ -34,7 +34,7 @@ export interface MarkdownInputProps {
   Controls?: (props: MarkdownControlsProps) => ReactNode;
 }
 
-function FormatButton({
+export function FormatButton({
   children,
   onClick,
 }: {
@@ -53,7 +53,7 @@ function FormatButton({
   );
 }
 
-const wrapSelection = ({
+export const wrapSelection = ({
   prefix,
   suffix,
   textArea,

--- a/packages/component-library/components/Form/inputs/Markdown/index.tsx
+++ b/packages/component-library/components/Form/inputs/Markdown/index.tsx
@@ -14,7 +14,6 @@ import { Button } from "component-library/components/Button";
 
 export interface MarkdownControlsProps {
   textArea: HTMLTextAreaElement | null;
-  setValue: (value: string) => void;
   setSelectionRange: (range: SelectionRange) => void;
 }
 
@@ -55,7 +54,6 @@ export const wrapSelection = ({
   prefix,
   suffix,
   textArea,
-  setValue,
   reselect = true,
   setSelectionRange,
 }: {
@@ -63,7 +61,6 @@ export const wrapSelection = ({
   suffix: string;
   reselect?: boolean;
   textArea: HTMLTextAreaElement | null;
-  setValue: (value: string) => void;
   setSelectionRange: (range: SelectionRange) => void;
 }) => {
   if (textArea) {
@@ -76,7 +73,7 @@ export const wrapSelection = ({
       selectedText +
       suffix +
       value.substring(selectionEnd);
-    setValue(newValue);
+    textArea.value = newValue;
     if (reselect) {
       setSelectionRange({
         selectionStart: selectionStart + prefix.length,
@@ -86,17 +83,12 @@ export const wrapSelection = ({
   }
 };
 
-function BoldControl({
-  textArea,
-  setValue,
-  setSelectionRange,
-}: MarkdownControlsProps) {
+function BoldControl({ textArea, setSelectionRange }: MarkdownControlsProps) {
   const handleBoldClick: MouseEventHandler<HTMLButtonElement> = () => {
     wrapSelection({
       prefix: "**",
       suffix: "**",
       textArea,
-      setValue,
       setSelectionRange,
     });
   };
@@ -108,17 +100,12 @@ function BoldControl({
   );
 }
 
-function ItalicControl({
-  textArea,
-  setValue,
-  setSelectionRange,
-}: MarkdownControlsProps) {
+function ItalicControl({ textArea, setSelectionRange }: MarkdownControlsProps) {
   const handleItalicClick: MouseEventHandler<HTMLButtonElement> = () => {
     wrapSelection({
       prefix: "*",
       suffix: "*",
       textArea,
-      setValue,
       setSelectionRange,
     });
   };
@@ -130,11 +117,7 @@ function ItalicControl({
   );
 }
 
-function LinkControl({
-  textArea,
-  setValue,
-  setSelectionRange,
-}: MarkdownControlsProps) {
+function LinkControl({ textArea, setSelectionRange }: MarkdownControlsProps) {
   const handleLinkClick: MouseEventHandler<HTMLButtonElement> = () => {
     if (textArea) {
       const value = textArea.value;
@@ -158,7 +141,6 @@ function LinkControl({
         prefix: "[",
         suffix: "](url)",
         textArea,
-        setValue,
         setSelectionRange,
         reselect: false,
       });
@@ -203,7 +185,6 @@ function getBlockquoteSelection({
 
 function BlockquoteControl({
   textArea,
-  setValue,
   setSelectionRange,
 }: MarkdownControlsProps) {
   const handleBlockquoteClick: MouseEventHandler<HTMLButtonElement> = () => {
@@ -241,7 +222,7 @@ function BlockquoteControl({
         quotedSelection +
         value.substring(selectionEnd);
 
-      setValue(newValue);
+      textArea.value = newValue;
 
       if (selectionStart === selectionEnd) {
         const blockquoteContentIndex =
@@ -266,11 +247,7 @@ function BlockquoteControl({
   );
 }
 
-function CodeControl({
-  textArea,
-  setValue,
-  setSelectionRange,
-}: MarkdownControlsProps) {
+function CodeControl({ textArea, setSelectionRange }: MarkdownControlsProps) {
   const handleCodeClick: MouseEventHandler<HTMLButtonElement> = () => {
     if (textArea) {
       const value = textArea.value;
@@ -283,7 +260,6 @@ function CodeControl({
           prefix: "\n```\n",
           suffix: "\n```\n",
           textArea,
-          setValue,
           setSelectionRange,
         });
       } else {
@@ -292,7 +268,6 @@ function CodeControl({
           prefix: "`",
           suffix: "`",
           textArea,
-          setValue,
           setSelectionRange,
         });
       }
@@ -308,34 +283,19 @@ function CodeControl({
 
 export function DefaultControls({
   textArea,
-  setValue,
   setSelectionRange,
 }: MarkdownControlsProps) {
   return (
     <>
-      <BoldControl
-        textArea={textArea}
-        setValue={setValue}
-        setSelectionRange={setSelectionRange}
-      />
+      <BoldControl textArea={textArea} setSelectionRange={setSelectionRange} />
       <ItalicControl
         textArea={textArea}
-        setValue={setValue}
         setSelectionRange={setSelectionRange}
       />
-      <CodeControl
-        textArea={textArea}
-        setValue={setValue}
-        setSelectionRange={setSelectionRange}
-      />
-      <LinkControl
-        textArea={textArea}
-        setValue={setValue}
-        setSelectionRange={setSelectionRange}
-      />
+      <CodeControl textArea={textArea} setSelectionRange={setSelectionRange} />
+      <LinkControl textArea={textArea} setSelectionRange={setSelectionRange} />
       <BlockquoteControl
         textArea={textArea}
-        setValue={setValue}
         setSelectionRange={setSelectionRange}
       />
     </>
@@ -351,7 +311,6 @@ export function MarkdownInput({
   Controls = DefaultControls,
 }: MarkdownInputProps) {
   const [activeTab, setActiveTab] = useState<"edit" | "preview">("edit");
-  const [value, setValue] = useState(defaultValue || "");
   const [selectionRange, setSelectionRange] = useState<
     SelectionRange | undefined
   >();
@@ -363,18 +322,18 @@ export function MarkdownInput({
       textArea.focus();
       textArea.setSelectionRange(selectionStart, selectionEnd);
     }
-  }, [selectionRange]);
+  }, [textArea, selectionRange]);
 
   return (
     <FieldWrapper label={label} id={id}>
       <Errors errors={errors} />
       <div className="flex flex-col border rounded">
-        <div className="flex border-b">
+        <div className="flex border-b overflow-hidden">
           <Button
             overrideDefaultStyles={true}
             className={clsx(
               activeTab === "edit" ? "bg-blue-500 text-white" : "",
-              "px-4 py-2 rounded-tl",
+              "px-4 py-2",
             )}
             onClick={() => setActiveTab("edit")}
           >
@@ -395,7 +354,6 @@ export function MarkdownInput({
           <div className="flex gap-2 border-b p-2">
             <Controls
               textArea={textArea}
-              setValue={setValue}
               setSelectionRange={setSelectionRange}
             />
           </div>
@@ -406,7 +364,7 @@ export function MarkdownInput({
               setTextArea(el);
             }}
             className={clsx(baseInputStyle, "px-1 h-40 grow w-full")}
-            value={value}
+            defaultValue={defaultValue}
           />
         </div>
         {activeTab === "preview" ? (

--- a/packages/component-library/components/Form/inputs/Markdown/index.tsx
+++ b/packages/component-library/components/Form/inputs/Markdown/index.tsx
@@ -14,7 +14,6 @@ import { Button } from "component-library/components/Button";
 
 export interface MarkdownControlsProps {
   textArea: HTMLTextAreaElement | null;
-  setSelectionRange: (range: SelectionRange) => void;
 }
 
 export interface SelectionRange {
@@ -55,13 +54,11 @@ export const wrapSelection = ({
   suffix,
   textArea,
   reselect = true,
-  setSelectionRange,
 }: {
   prefix: string;
   suffix: string;
   reselect?: boolean;
   textArea: HTMLTextAreaElement | null;
-  setSelectionRange: (range: SelectionRange) => void;
 }) => {
   if (textArea) {
     const value = textArea.value;
@@ -75,21 +72,21 @@ export const wrapSelection = ({
       value.substring(selectionEnd);
     textArea.value = newValue;
     if (reselect) {
-      setSelectionRange({
-        selectionStart: selectionStart + prefix.length,
-        selectionEnd: selectionEnd + prefix.length,
-      });
+      textArea.focus();
+      textArea.setSelectionRange(
+        selectionStart + prefix.length,
+        selectionEnd + prefix.length,
+      );
     }
   }
 };
 
-function BoldControl({ textArea, setSelectionRange }: MarkdownControlsProps) {
+function BoldControl({ textArea }: MarkdownControlsProps) {
   const handleBoldClick: MouseEventHandler<HTMLButtonElement> = () => {
     wrapSelection({
       prefix: "**",
       suffix: "**",
       textArea,
-      setSelectionRange,
     });
   };
 
@@ -100,13 +97,12 @@ function BoldControl({ textArea, setSelectionRange }: MarkdownControlsProps) {
   );
 }
 
-function ItalicControl({ textArea, setSelectionRange }: MarkdownControlsProps) {
+function ItalicControl({ textArea }: MarkdownControlsProps) {
   const handleItalicClick: MouseEventHandler<HTMLButtonElement> = () => {
     wrapSelection({
       prefix: "*",
       suffix: "*",
       textArea,
-      setSelectionRange,
     });
   };
 
@@ -117,7 +113,7 @@ function ItalicControl({ textArea, setSelectionRange }: MarkdownControlsProps) {
   );
 }
 
-function LinkControl({ textArea, setSelectionRange }: MarkdownControlsProps) {
+function LinkControl({ textArea }: MarkdownControlsProps) {
   const handleLinkClick: MouseEventHandler<HTMLButtonElement> = () => {
     if (textArea) {
       const value = textArea.value;
@@ -141,13 +137,10 @@ function LinkControl({ textArea, setSelectionRange }: MarkdownControlsProps) {
         prefix: "[",
         suffix: "](url)",
         textArea,
-        setSelectionRange,
         reselect: false,
       });
-      setSelectionRange({
-        selectionStart: newSelectionStart,
-        selectionEnd: newSelectionEnd,
-      });
+      textArea.focus();
+      textArea.setSelectionRange(newSelectionStart, newSelectionEnd);
     }
   };
 
@@ -183,10 +176,7 @@ function getBlockquoteSelection({
   }
 }
 
-function BlockquoteControl({
-  textArea,
-  setSelectionRange,
-}: MarkdownControlsProps) {
+function BlockquoteControl({ textArea }: MarkdownControlsProps) {
   const handleBlockquoteClick: MouseEventHandler<HTMLButtonElement> = () => {
     if (textArea) {
       const value = textArea.value;
@@ -227,15 +217,17 @@ function BlockquoteControl({
       if (selectionStart === selectionEnd) {
         const blockquoteContentIndex =
           selectionStart + quotedSelection.indexOf("> ") + 2;
-        setSelectionRange({
-          selectionStart: blockquoteContentIndex,
-          selectionEnd: blockquoteContentIndex,
-        });
+        textArea.focus();
+        textArea.setSelectionRange(
+          blockquoteContentIndex,
+          blockquoteContentIndex,
+        );
       } else {
-        setSelectionRange({
+        textArea.focus();
+        textArea.setSelectionRange(
           selectionStart,
-          selectionEnd: selectionStart + quotedSelection.length,
-        });
+          selectionStart + quotedSelection.length,
+        );
       }
     }
   };
@@ -247,7 +239,7 @@ function BlockquoteControl({
   );
 }
 
-function CodeControl({ textArea, setSelectionRange }: MarkdownControlsProps) {
+function CodeControl({ textArea }: MarkdownControlsProps) {
   const handleCodeClick: MouseEventHandler<HTMLButtonElement> = () => {
     if (textArea) {
       const value = textArea.value;
@@ -260,7 +252,6 @@ function CodeControl({ textArea, setSelectionRange }: MarkdownControlsProps) {
           prefix: "\n```\n",
           suffix: "\n```\n",
           textArea,
-          setSelectionRange,
         });
       } else {
         // Inline code
@@ -268,7 +259,6 @@ function CodeControl({ textArea, setSelectionRange }: MarkdownControlsProps) {
           prefix: "`",
           suffix: "`",
           textArea,
-          setSelectionRange,
         });
       }
     }
@@ -281,23 +271,14 @@ function CodeControl({ textArea, setSelectionRange }: MarkdownControlsProps) {
   );
 }
 
-export function DefaultControls({
-  textArea,
-  setSelectionRange,
-}: MarkdownControlsProps) {
+export function DefaultControls({ textArea }: MarkdownControlsProps) {
   return (
     <>
-      <BoldControl textArea={textArea} setSelectionRange={setSelectionRange} />
-      <ItalicControl
-        textArea={textArea}
-        setSelectionRange={setSelectionRange}
-      />
-      <CodeControl textArea={textArea} setSelectionRange={setSelectionRange} />
-      <LinkControl textArea={textArea} setSelectionRange={setSelectionRange} />
-      <BlockquoteControl
-        textArea={textArea}
-        setSelectionRange={setSelectionRange}
-      />
+      <BoldControl textArea={textArea} />
+      <ItalicControl textArea={textArea} />
+      <CodeControl textArea={textArea} />
+      <LinkControl textArea={textArea} />
+      <BlockquoteControl textArea={textArea} />
     </>
   );
 }
@@ -311,18 +292,7 @@ export function MarkdownInput({
   Controls = DefaultControls,
 }: MarkdownInputProps) {
   const [activeTab, setActiveTab] = useState<"edit" | "preview">("edit");
-  const [selectionRange, setSelectionRange] = useState<
-    SelectionRange | undefined
-  >();
   const [textArea, setTextArea] = useState<HTMLTextAreaElement | null>(null);
-
-  useEffect(() => {
-    if (textArea && selectionRange) {
-      const { selectionStart, selectionEnd } = selectionRange;
-      textArea.focus();
-      textArea.setSelectionRange(selectionStart, selectionEnd);
-    }
-  }, [textArea, selectionRange]);
 
   return (
     <FieldWrapper label={label} id={id}>
@@ -343,19 +313,18 @@ export function MarkdownInput({
             overrideDefaultStyles={true}
             className={clsx(
               activeTab === "preview" ? "bg-blue-500 text-white" : "",
-              "px-4 py-2 rounded-tr",
+              "px-4 py-2",
             )}
-            onClick={() => setActiveTab("preview")}
+            onClick={() => {
+              setActiveTab("preview");
+            }}
           >
             Preview
           </Button>
         </div>
         <div className={activeTab === "edit" ? "" : "hidden"}>
           <div className="flex gap-2 border-b p-2">
-            <Controls
-              textArea={textArea}
-              setSelectionRange={setSelectionRange}
-            />
+            <Controls textArea={textArea} />
           </div>
           <textarea
             name={name}
@@ -369,7 +338,7 @@ export function MarkdownInput({
         </div>
         {activeTab === "preview" ? (
           <div className={"p-2 markdown-body"}>
-            <StyledMarkdown>{value}</StyledMarkdown>
+            <StyledMarkdown>{textArea?.value || ""}</StyledMarkdown>
           </div>
         ) : null}
       </div>

--- a/websites/portfolio/editor/src/app/(editor)/homepage/HomepageInput.tsx
+++ b/websites/portfolio/editor/src/app/(editor)/homepage/HomepageInput.tsx
@@ -10,16 +10,12 @@ import {
 } from "component-library/components/Form/inputs/Markdown";
 import { MouseEventHandler } from "react";
 
-function HighlightControl({
-  textArea,
-  setSelectionRange,
-}: MarkdownControlsProps) {
+function HighlightControl({ textArea }: MarkdownControlsProps) {
   const handleHighlightClick: MouseEventHandler<HTMLButtonElement> = () => {
     wrapSelection({
       prefix: "<mark>",
       suffix: "</mark>",
       textArea,
-      setSelectionRange,
     });
   };
 
@@ -32,30 +28,24 @@ function HighlightControl({
   );
 }
 
-function DetailsControl({
-  textArea,
-  setSelectionRange,
-}: MarkdownControlsProps) {
+function DetailsControl({ textArea }: MarkdownControlsProps) {
   const handleDetailsClick: MouseEventHandler<HTMLButtonElement> = () => {
     if (textArea) {
       const { selectionStart } = textArea;
 
       const prefix = `<details>\n<summary></summary>\n`;
       const suffix = `\n</details>`;
-      const newSelectionStart = selectionStart + 19; // After <summary>
+      const newSelectionStart = selectionStart + 19;
       const newSelectionEnd = newSelectionStart;
 
       wrapSelection({
         prefix,
         suffix,
         textArea,
-        setSelectionRange,
         reselect: false,
       });
-      setSelectionRange({
-        selectionStart: newSelectionStart,
-        selectionEnd: newSelectionEnd,
-      });
+      textArea.focus();
+      textArea.setSelectionRange(newSelectionStart, newSelectionEnd);
     }
   };
 
@@ -66,24 +56,12 @@ function DetailsControl({
   );
 }
 
-function CustomControls({
-  textArea,
-  setSelectionRange,
-}: MarkdownControlsProps) {
+function CustomControls({ textArea }: MarkdownControlsProps) {
   return (
     <>
-      <DefaultControls
-        textArea={textArea}
-        setSelectionRange={setSelectionRange}
-      />
-      <HighlightControl
-        textArea={textArea}
-        setSelectionRange={setSelectionRange}
-      />
-      <DetailsControl
-        textArea={textArea}
-        setSelectionRange={setSelectionRange}
-      />
+      <DefaultControls textArea={textArea} />
+      <HighlightControl textArea={textArea} />
+      <DetailsControl textArea={textArea} />
     </>
   );
 }

--- a/websites/portfolio/editor/src/app/(editor)/homepage/HomepageInput.tsx
+++ b/websites/portfolio/editor/src/app/(editor)/homepage/HomepageInput.tsx
@@ -36,6 +36,47 @@ export function HighlightControl({
   );
 }
 
+export function DetailsControl({
+  textAreaRef,
+  setValue,
+  setSelectionRange,
+  onChange,
+}: MarkdownControlsProps) {
+  const textArea = textAreaRef.current;
+
+  const handleDetailsClick: MouseEventHandler<HTMLButtonElement> = () => {
+    if (textArea) {
+      const value = textArea.value;
+      const { selectionStart, selectionEnd } = textArea;
+      const selectedText = value.substring(selectionStart, selectionEnd);
+
+      const prefix = `<details>\n<summary></summary>\n${selectedText}\n</details>`;
+      const newSelectionStart = selectionStart + 10; // After <summary>
+      const newSelectionEnd = newSelectionStart;
+
+      wrapSelection({
+        prefix,
+        suffix: "",
+        textArea,
+        setValue,
+        setSelectionRange,
+        onChange,
+        reselect: false,
+      });
+      setSelectionRange({
+        selectionStart: newSelectionStart,
+        selectionEnd: newSelectionEnd,
+      });
+    }
+  };
+
+  return (
+    <FormatButton onClick={handleDetailsClick}>
+      <span className="text-xs">Dtl</span>
+    </FormatButton>
+  );
+}
+
 export function CustomControls({
   textAreaRef,
   setValue,
@@ -51,6 +92,12 @@ export function CustomControls({
         onChange={onChange}
       />
       <HighlightControl
+        textAreaRef={textAreaRef}
+        setValue={setValue}
+        setSelectionRange={setSelectionRange}
+        onChange={onChange}
+      />
+      <DetailsControl
         textAreaRef={textAreaRef}
         setValue={setValue}
         setSelectionRange={setSelectionRange}

--- a/websites/portfolio/editor/src/app/(editor)/homepage/HomepageInput.tsx
+++ b/websites/portfolio/editor/src/app/(editor)/homepage/HomepageInput.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import {
+  MarkdownInput,
+  MarkdownInputProps,
+} from "component-library/components/Form/inputs/Markdown";
+
+export default function HomepageMarkdownInput({
+  name,
+  id,
+  label,
+  defaultValue,
+  onChange,
+  errors,
+}: MarkdownInputProps) {
+  return (
+    <MarkdownInput
+      name={name}
+      id={id}
+      label={label}
+      defaultValue={defaultValue}
+      onChange={onChange}
+      errors={errors}
+    />
+  );
+}

--- a/websites/portfolio/editor/src/app/(editor)/homepage/HomepageInput.tsx
+++ b/websites/portfolio/editor/src/app/(editor)/homepage/HomepageInput.tsx
@@ -11,13 +11,10 @@ import {
 import { MouseEventHandler } from "react";
 
 export function HighlightControl({
-  textAreaRef,
+  textArea,
   setValue,
   setSelectionRange,
-  onChange,
 }: MarkdownControlsProps) {
-  const textArea = textAreaRef.current;
-
   const handleHighlightClick: MouseEventHandler<HTMLButtonElement> = () => {
     wrapSelection({
       prefix: "<mark>",
@@ -25,7 +22,6 @@ export function HighlightControl({
       textArea,
       setValue,
       setSelectionRange,
-      onChange,
     });
   };
 
@@ -37,13 +33,10 @@ export function HighlightControl({
 }
 
 export function DetailsControl({
-  textAreaRef,
+  textArea,
   setValue,
   setSelectionRange,
-  onChange,
 }: MarkdownControlsProps) {
-  const textArea = textAreaRef.current;
-
   const handleDetailsClick: MouseEventHandler<HTMLButtonElement> = () => {
     if (textArea) {
       const { selectionStart } = textArea;
@@ -59,7 +52,6 @@ export function DetailsControl({
         textArea,
         setValue,
         setSelectionRange,
-        onChange,
         reselect: false,
       });
       setSelectionRange({
@@ -77,30 +69,26 @@ export function DetailsControl({
 }
 
 export function CustomControls({
-  textAreaRef,
+  textArea,
   setValue,
   setSelectionRange,
-  onChange,
 }: MarkdownControlsProps) {
   return (
     <>
       <DefaultControls
-        textAreaRef={textAreaRef}
+        textArea={textArea}
         setValue={setValue}
         setSelectionRange={setSelectionRange}
-        onChange={onChange}
       />
       <HighlightControl
-        textAreaRef={textAreaRef}
+        textArea={textArea}
         setValue={setValue}
         setSelectionRange={setSelectionRange}
-        onChange={onChange}
       />
       <DetailsControl
-        textAreaRef={textAreaRef}
+        textArea={textArea}
         setValue={setValue}
         setSelectionRange={setSelectionRange}
-        onChange={onChange}
       />
     </>
   );
@@ -111,7 +99,6 @@ export default function HomepageMarkdownInput({
   id,
   label,
   defaultValue,
-  onChange,
   errors,
 }: MarkdownInputProps) {
   return (
@@ -120,7 +107,6 @@ export default function HomepageMarkdownInput({
       id={id}
       label={label}
       defaultValue={defaultValue}
-      onChange={onChange}
       errors={errors}
       Controls={CustomControls}
     />

--- a/websites/portfolio/editor/src/app/(editor)/homepage/HomepageInput.tsx
+++ b/websites/portfolio/editor/src/app/(editor)/homepage/HomepageInput.tsx
@@ -46,17 +46,16 @@ export function DetailsControl({
 
   const handleDetailsClick: MouseEventHandler<HTMLButtonElement> = () => {
     if (textArea) {
-      const value = textArea.value;
-      const { selectionStart, selectionEnd } = textArea;
-      const selectedText = value.substring(selectionStart, selectionEnd);
+      const { selectionStart } = textArea;
 
-      const prefix = `<details>\n<summary></summary>\n${selectedText}\n</details>`;
-      const newSelectionStart = selectionStart + 10; // After <summary>
+      const prefix = `<details>\n<summary></summary>\n`;
+      const suffix = `\n</details>`;
+      const newSelectionStart = selectionStart + 19; // After <summary>
       const newSelectionEnd = newSelectionStart;
 
       wrapSelection({
         prefix,
-        suffix: "",
+        suffix,
         textArea,
         setValue,
         setSelectionRange,

--- a/websites/portfolio/editor/src/app/(editor)/homepage/HomepageInput.tsx
+++ b/websites/portfolio/editor/src/app/(editor)/homepage/HomepageInput.tsx
@@ -1,9 +1,64 @@
 "use client";
 
 import {
+  DefaultControls,
+  FormatButton,
+  MarkdownControlsProps,
   MarkdownInput,
   MarkdownInputProps,
+  wrapSelection,
 } from "component-library/components/Form/inputs/Markdown";
+import { MouseEventHandler } from "react";
+
+export function HighlightControl({
+  textAreaRef,
+  setValue,
+  setSelectionRange,
+  onChange,
+}: MarkdownControlsProps) {
+  const textArea = textAreaRef.current;
+
+  const handleHighlightClick: MouseEventHandler<HTMLButtonElement> = () => {
+    wrapSelection({
+      prefix: "<mark>",
+      suffix: "</mark>",
+      textArea,
+      setValue,
+      setSelectionRange,
+      onChange,
+    });
+  };
+
+  return (
+    <FormatButton onClick={handleHighlightClick}>
+      <mark className="bg-yellow-200">H</mark>
+    </FormatButton>
+  );
+}
+
+export function CustomControls({
+  textAreaRef,
+  setValue,
+  setSelectionRange,
+  onChange,
+}: MarkdownControlsProps) {
+  return (
+    <>
+      <DefaultControls
+        textAreaRef={textAreaRef}
+        setValue={setValue}
+        setSelectionRange={setSelectionRange}
+        onChange={onChange}
+      />
+      <HighlightControl
+        textAreaRef={textAreaRef}
+        setValue={setValue}
+        setSelectionRange={setSelectionRange}
+        onChange={onChange}
+      />
+    </>
+  );
+}
 
 export default function HomepageMarkdownInput({
   name,
@@ -21,6 +76,7 @@ export default function HomepageMarkdownInput({
       defaultValue={defaultValue}
       onChange={onChange}
       errors={errors}
+      Controls={CustomControls}
     />
   );
 }

--- a/websites/portfolio/editor/src/app/(editor)/homepage/HomepageInput.tsx
+++ b/websites/portfolio/editor/src/app/(editor)/homepage/HomepageInput.tsx
@@ -10,9 +10,8 @@ import {
 } from "component-library/components/Form/inputs/Markdown";
 import { MouseEventHandler } from "react";
 
-export function HighlightControl({
+function HighlightControl({
   textArea,
-  setValue,
   setSelectionRange,
 }: MarkdownControlsProps) {
   const handleHighlightClick: MouseEventHandler<HTMLButtonElement> = () => {
@@ -20,21 +19,21 @@ export function HighlightControl({
       prefix: "<mark>",
       suffix: "</mark>",
       textArea,
-      setValue,
       setSelectionRange,
     });
   };
 
   return (
     <FormatButton onClick={handleHighlightClick}>
-      <mark className="bg-yellow-200">H</mark>
+      <mark className="text-sm block mx-auto h-4 w-4 leading-none rounded">
+        H
+      </mark>
     </FormatButton>
   );
 }
 
-export function DetailsControl({
+function DetailsControl({
   textArea,
-  setValue,
   setSelectionRange,
 }: MarkdownControlsProps) {
   const handleDetailsClick: MouseEventHandler<HTMLButtonElement> = () => {
@@ -50,7 +49,6 @@ export function DetailsControl({
         prefix,
         suffix,
         textArea,
-        setValue,
         setSelectionRange,
         reselect: false,
       });
@@ -68,26 +66,22 @@ export function DetailsControl({
   );
 }
 
-export function CustomControls({
+function CustomControls({
   textArea,
-  setValue,
   setSelectionRange,
 }: MarkdownControlsProps) {
   return (
     <>
       <DefaultControls
         textArea={textArea}
-        setValue={setValue}
         setSelectionRange={setSelectionRange}
       />
       <HighlightControl
         textArea={textArea}
-        setValue={setValue}
         setSelectionRange={setSelectionRange}
       />
       <DetailsControl
         textArea={textArea}
-        setValue={setValue}
         setSelectionRange={setSelectionRange}
       />
     </>

--- a/websites/portfolio/editor/src/app/(editor)/homepage/page.tsx
+++ b/websites/portfolio/editor/src/app/(editor)/homepage/page.tsx
@@ -11,7 +11,7 @@ import {
   uploadsDirectory,
 } from "portfolio-website-common/homepage-controller/paths";
 import { HomepageProjectItem } from "portfolio-website-common/homepage-controller/types";
-import { MarkdownInput } from "component-library/components/Form/inputs/Markdown";
+import MarkdownInput from "./HomepageInput";
 import { HomepageUploadInputItem, UploadsListInput } from "./UploadsList";
 import { readdir } from "fs-extra";
 


### PR DESCRIPTION
This PR overhauls the `MarkdownInput` component to allow passing in a custom `Controls` component which gets passed a reference to the `textarea` in order to manipulate its contents and selection. The existing controls have been turned into reusable components, as well as a single component that contains all the defaults.