### PR TITLE
Add "Seeking" feature to search

### DIFF
--- a/packages/recipes-collection/components/SearchForm/index.tsx
+++ b/packages/recipes-collection/components/SearchForm/index.tsx
@@ -118,7 +118,7 @@ function SearchFormQuery({ firstPage }: { firstPage: ReadRecipeIndexResult }) {
     } else {
       setSeeking(undefined);
     }
-  }, [seeking, searchedRecipes, setSeeking, data.pages]);
+  }, [seeking, searchedRecipes, setSeeking, data.pages, fetchNextPage]);
 
   return (
     <>

--- a/packages/recipes-collection/components/SearchForm/index.tsx
+++ b/packages/recipes-collection/components/SearchForm/index.tsx
@@ -106,6 +106,20 @@ function SearchFormQuery({ firstPage }: { firstPage: ReadRecipeIndexResult }) {
     [store, searchedRecipeIds],
   );
 
+  const [seeking, setSeeking] = useState<number | undefined>();
+
+  useEffect(() => {
+    if (
+      seeking !== undefined &&
+      searchedRecipes &&
+      searchedRecipes.length <= seeking
+    ) {
+      fetchNextPage();
+    } else {
+      setSeeking(undefined);
+    }
+  }, [seeking, searchedRecipes, setSeeking, data.pages]);
+
   return (
     <>
       <form
@@ -116,6 +130,7 @@ function SearchFormQuery({ firstPage }: { firstPage: ReadRecipeIndexResult }) {
             query: { value: string };
           };
           setQuery(elements.query.value || undefined);
+          setSeeking(searchedRecipes?.length || 0);
         }}
       >
         <TextInput name="query" label="Query" />
@@ -131,7 +146,9 @@ function SearchFormQuery({ firstPage }: { firstPage: ReadRecipeIndexResult }) {
           )}
           <div>
             <Button
-              onClick={() => fetchNextPage()}
+              onClick={() => {
+                setSeeking(searchedRecipes?.length);
+              }}
               disabled={!hasNextPage || isFetchingNextPage}
             >
               {isFetchingNextPage


### PR DESCRIPTION
This PR modifies the search feature to keep loading pages until it finds an item, called "seeking". Seeking starts when a search is initiated, as well as when the "Load More" button is pressed. Once a new item is found, seeking stops and the "Load More" button can be used to initiate seeking again if more results are desired.