### PR TITLE
Make RecipeImage log errors and continue instead of throwing

### DIFF
--- a/packages/recipes-collection/components/RecipeImage/index.tsx
+++ b/packages/recipes-collection/components/RecipeImage/index.tsx
@@ -43,11 +43,20 @@ export async function getTransformedRecipeImageProps({
 
 export async function RecipeImage(inputProps: TransformedRecipeImageProps) {
   if (inputProps.image) {
-    const image = await getTransformedRecipeImageProps(inputProps);
-    return (
-      <Image {...image.props} alt={inputProps.alt} unoptimized={true}>
-        {null}
-      </Image>
-    );
+    try {
+      const image = await getTransformedRecipeImageProps(inputProps);
+      return (
+        <Image {...image.props} alt={inputProps.alt} unoptimized={true}>
+          {null}
+        </Image>
+      );
+    } catch (e) {
+      const { code, message } = e as { code?: string; message?: string };
+      console.warn(
+        `RecipeImage "${inputProps.image}" failed with error` +
+          (code ? `code ${code}` : "") +
+          (message ? `: ${message}` : ""),
+      );
+    }
   }
 }


### PR DESCRIPTION
This small PR changes `RecipeImage` so that the recipe website will log image errors instead of making the website throw. This is particularly useful when raw data is imported from past or other sources.