### PR TITLE
Use recipe names for single recipe view metadata titles

### DIFF
--- a/websites/recipe-website/editor/cypress/e2e/edit.cy.ts
+++ b/websites/recipe-website/editor/cypress/e2e/edit.cy.ts
@@ -35,7 +35,7 @@ describe("Recipe Edit View", () => {
 
         cy.findByText("Submit").click();
 
-        cy.findByText(editedRecipeTitle);
+        cy.findByText(editedRecipeTitle, { selector: "h1" });
 
         cy.visit("/");
         cy.findByText(editedRecipeTitle);
@@ -117,7 +117,7 @@ describe("Recipe Edit View", () => {
 
         cy.findByText("Submit").click();
 
-        cy.findByText("Recipe 5");
+        cy.findByText("Recipe 5", { selector: "h1" });
         // Image on view page should be alternate
         cy.findByRole("img").should(
           "have.attr",
@@ -165,7 +165,7 @@ describe("Recipe Edit View", () => {
 
         cy.findByText("Submit").click();
 
-        cy.findByText(editedRecipeTitle);
+        cy.findByText(editedRecipeTitle, { selector: "h1" });
         cy.findByRole("img").should(
           "have.attr",
           "src",

--- a/websites/recipe-website/editor/cypress/e2e/git.cy.ts
+++ b/websites/recipe-website/editor/cypress/e2e/git.cy.ts
@@ -36,7 +36,7 @@ describe("Git content", () => {
         cy.visit("/new-recipe");
         cy.findByLabelText("Name").type(recipeName);
         cy.findByText("Submit").click();
-        cy.findByText(recipeName);
+        cy.findByText(recipeName, { selector: "h1" });
       }
 
       // Make two recipes to build some test history
@@ -57,7 +57,7 @@ describe("Git content", () => {
       cy.findAllByLabelText("Name").first().clear();
       cy.findAllByLabelText("Name").first().type(editedTestName);
       cy.findByText("Submit").click();
-      cy.findByText(editedTestName);
+      cy.findByText(editedTestName, { selector: "h1" });
 
       // Delete first recipe
       cy.visit("/");

--- a/websites/recipe-website/editor/cypress/e2e/homepage.cy.ts
+++ b/websites/recipe-website/editor/cypress/e2e/homepage.cy.ts
@@ -26,7 +26,7 @@ describe("Index Page", () => {
 
       cy.findByLabelText("Name").type(testRecipe);
       cy.findByText("Submit").click();
-      cy.findByText(testRecipe);
+      cy.findByText(testRecipe, { selector: "h1" });
 
       // Check home and ensure the recipe is present
       cy.visit("/");
@@ -54,7 +54,7 @@ describe("Index Page", () => {
         cy.visit("/new-recipe");
         cy.findByLabelText("Name").type(testRecipe);
         cy.findByText("Submit").click();
-        cy.findByText(testRecipe);
+        cy.findByText(testRecipe, { selector: "h1" });
       }
 
       cy.visit("/");

--- a/websites/recipe-website/editor/cypress/e2e/recipe.cy.ts
+++ b/websites/recipe-website/editor/cypress/e2e/recipe.cy.ts
@@ -6,7 +6,8 @@ describe("Single Recipe View", () => {
     });
 
     it("should display a recipe", () => {
-      cy.findByText("Recipe 6");
+      cy.findByText("Recipe 6", { selector: "h1" });
+      cy.get("title").should("contain.text", "Recipe 6");
     });
 
     it("should not need authorization", () => {
@@ -40,7 +41,7 @@ describe("Single Recipe View", () => {
 
       cy.findByText("Submit").click();
 
-      cy.findByText(editedRecipe);
+      cy.findByText(editedRecipe, { selector: "h1" });
 
       cy.visit("/");
       cy.findByText(editedRecipe);


### PR DESCRIPTION
Does what it says on the tin, but also required a lot of edits in the tests because `findByText` for recipe titles picked up both the original title and this one, fixed by adding `{selector: "h1"}` which probably should also be used to replace the `cy.get`s hanging around in the future.