### PR TITLE
Re-add mocha to eslint 9

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@
 import nextPlugin from "@next/eslint-plugin-next";
 import reactPlugin from "eslint-plugin-react";
 import hooksPlugin from "eslint-plugin-react-hooks";
+import mochaPlugin from "eslint-plugin-mocha";
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 import { fixupPluginRules } from "@eslint/compat";
@@ -24,12 +25,14 @@ export default [
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
+  mochaPlugin.configs.flat.recommended,
   {
     files: ["**/*.ts", "**/*.tsx"],
     plugins: {
       react: reactPlugin,
       "react-hooks": patchedHooksPlugin,
       "@next/next": patchedNextPlugin,
+      mocha: mochaPlugin,
     },
     rules: {
       ...reactPlugin.configs["jsx-runtime"].rules,

--- a/websites/portfolio/editor/cypress/e2e/edit.cy.ts
+++ b/websites/portfolio/editor/cypress/e2e/edit.cy.ts
@@ -1,26 +1,26 @@
-describe("Project Edit View", () => {
-  describe("with seven items", () => {
-    beforeEach(() => {
+describe("Project Edit View", function () {
+  describe("with seven items", function () {
+    beforeEach(function () {
       cy.resetData("two-pages");
       cy.visit("/project/project-6/edit");
     });
 
-    it("should need authorization", () => {
+    it("should need authorization", function () {
       cy.findByText("Sign in with Credentials");
     });
 
-    it("should require authorization even when project doesn't exist", () => {
+    it("should require authorization even when project doesn't exist", function () {
       cy.visit({
         url: "/project/non-existent-project/edit",
       });
     });
 
-    describe("when authenticated", () => {
-      beforeEach(() => {
+    describe("when authenticated", function () {
+      beforeEach(function () {
         cy.fillSignInForm();
       });
 
-      it("should be able to edit a project", () => {
+      it("should be able to edit a project", function () {
         cy.findByText("Editing Project: Project 6");
 
         cy.findByText("Advanced").click();
@@ -52,7 +52,7 @@ describe("Project Edit View", () => {
         cy.findByText(new Date(projectDate + "Z").toLocaleString());
       });
 
-      it("should be able to set a project image over another image", () => {
+      it("should be able to set a project image over another image", function () {
         cy.findByText("Editing Project: Project 6");
 
         // Image preview should be current image
@@ -95,7 +95,7 @@ describe("Project Edit View", () => {
           );
       });
 
-      it("should be able to set a project image on a project without an image", () => {
+      it("should be able to set a project image on a project without an image", function () {
         cy.visit("/project/project-5/edit");
         cy.findByText("Editing Project: Project 5");
 
@@ -139,7 +139,7 @@ describe("Project Edit View", () => {
           );
       });
 
-      it("should be able to remove an image", () => {
+      it("should be able to remove an image", function () {
         cy.findByText("Editing Project: Project 6");
 
         cy.findByRole("img");
@@ -155,7 +155,7 @@ describe("Project Edit View", () => {
         cy.findAllByLabelText("Remove Image").should("not.exist");
       });
 
-      it("should be able to preserve an image when editing", () => {
+      it("should be able to preserve an image when editing", function () {
         cy.findByText("Editing Project: Project 6");
 
         cy.findByRole("img");
@@ -186,7 +186,7 @@ describe("Project Edit View", () => {
         cy.findByLabelText("Remove Image");
       });
 
-      it("should have status 404 when project doesn't exist", () => {
+      it("should have status 404 when project doesn't exist", function () {
         cy.request({
           url: "/project/non-existent-project/edit",
           failOnStatusCode: false,

--- a/websites/portfolio/editor/cypress/e2e/homepage.cy.ts
+++ b/websites/portfolio/editor/cypress/e2e/homepage.cy.ts
@@ -1,19 +1,19 @@
-describe("Index Page", () => {
-  describe("when empty", () => {
-    beforeEach(() => {
+describe("Index Page", function () {
+  describe("when empty", function () {
+    beforeEach(function () {
       cy.resetData();
       cy.visit("/");
     });
 
-    it("should not need authorization", () => {
+    it("should not need authorization", function () {
       cy.findByText("Sign In");
     });
 
-    it("should inform the user if there are no projects", () => {
+    it("should inform the user if there are no projects", function () {
       cy.findByText("There are no projects yet.");
     });
 
-    it("should be able to create and delete a project", () => {
+    it("should be able to create and delete a project", function () {
       const testProject = "Test Project";
 
       // We should start with no projects
@@ -44,7 +44,7 @@ describe("Index Page", () => {
         .should("equal", 404);
     });
 
-    it("should be able to create projects and see them in chronological order", () => {
+    it("should be able to create projects and see them in chronological order", function () {
       cy.findByText("Sign In").click();
 
       cy.fillSignInForm();
@@ -62,13 +62,13 @@ describe("Index Page", () => {
     });
   });
 
-  describe("with just enough items for the front page", () => {
-    beforeEach(() => {
+  describe("with just enough items for the front page", function () {
+    beforeEach(function () {
       cy.resetData("front-page-only");
       cy.visit("/");
     });
 
-    it("should not display a link to the index", () => {
+    it("should not display a link to the index", function () {
       const allNames = [3, 2, 1].map((x) => `Project ${x}`);
 
       // Homepage should have latest three projects
@@ -78,13 +78,13 @@ describe("Index Page", () => {
     });
   });
 
-  describe("with seven items", () => {
-    beforeEach(() => {
+  describe("with seven items", function () {
+    beforeEach(function () {
       cy.resetData("two-pages");
       cy.visit("/");
     });
 
-    it("should display the latest six projects", () => {
+    it("should display the latest six projects", function () {
       const allNames = [7, 6, 5, 4, 3, 2, 1].map((x) => `Project ${x}`);
 
       // Homepage should have latest three projects

--- a/websites/portfolio/editor/cypress/e2e/menus.cy.ts
+++ b/websites/portfolio/editor/cypress/e2e/menus.cy.ts
@@ -1,25 +1,25 @@
-describe("Menu Editor", () => {
-  describe("with a clean slate", () => {
-    beforeEach(() => {
+describe("Menu Editor", function () {
+  describe("with a clean slate", function () {
+    beforeEach(function () {
       cy.resetData();
       cy.visit("/menus");
     });
 
-    it("should need authorization", () => {
+    it("should need authorization", function () {
       cy.findByText("Sign in with Credentials");
     });
 
-    it("should need authorization when directly going to edit the header", () => {
+    it("should need authorization when directly going to edit the header", function () {
       cy.visit("/menus/edit/header");
       cy.findByText("Sign in with Credentials");
     });
 
-    describe("when authenticated", () => {
-      beforeEach(() => {
+    describe("when authenticated", function () {
+      beforeEach(function () {
         cy.fillSignInForm();
       });
 
-      it("should be able to add to, edit, and clear the header nav", () => {
+      it("should be able to add to, edit, and clear the header nav", function () {
         // Add nav item to header
 
         cy.findByText("Header").click();
@@ -59,7 +59,7 @@ describe("Menu Editor", () => {
         cy.findAllByText("About").should("not.exist");
       });
 
-      it("should be able to add to, edit, and clear the footer nav", () => {
+      it("should be able to add to, edit, and clear the footer nav", function () {
         // Add nav item to footer
 
         cy.findByText("Footer").click();

--- a/websites/portfolio/editor/cypress/e2e/new-project.cy.ts
+++ b/websites/portfolio/editor/cypress/e2e/new-project.cy.ts
@@ -1,20 +1,20 @@
-describe("New Project View", () => {
-  describe("with the importable uploads fixture", () => {
-    beforeEach(() => {
+describe("New Project View", function () {
+  describe("with the importable uploads fixture", function () {
+    beforeEach(function () {
       cy.resetData("importable-uploads");
       cy.visit("/new-project");
     });
 
-    it("should need authentication", () => {
+    it("should need authentication", function () {
       cy.findByText("Sign in with Credentials");
     });
 
-    describe("when authenticated", () => {
-      beforeEach(() => {
+    describe("when authenticated", function () {
+      beforeEach(function () {
         cy.fillSignInForm();
       });
 
-      it("should be able to create a new project", () => {
+      it("should be able to create a new project", function () {
         cy.findByRole("heading", { name: "New Project" });
 
         const newProjectTitle = "My New Project";
@@ -33,7 +33,7 @@ describe("New Project View", () => {
         cy.checkNamesInOrder([newProjectTitle]);
       });
 
-      it("should be able to paste ingredients", () => {
+      it("should be able to paste ingredients", function () {
         cy.findByRole("heading", { name: "New Project" });
 
         const newProjectTitle = "My New Project";
@@ -89,7 +89,7 @@ describe("New Project View", () => {
         );
       });
 
-      it("should be able to import a project", () => {
+      it("should be able to import a project", function () {
         const baseURL = Cypress.config().baseUrl;
         const testURL = "/uploads/katsudon.html";
         const fullTestURL = new URL(testURL, baseURL);
@@ -142,7 +142,7 @@ describe("New Project View", () => {
         });
       });
 
-      it("should be able to import a project with an image", () => {
+      it("should be able to import a project with an image", function () {
         const baseURL = Cypress.config().baseUrl;
         const testURL = "/uploads/blackstone-nachos.html";
         const fullTestURL = new URL(testURL, baseURL);
@@ -226,7 +226,7 @@ describe("New Project View", () => {
         cy.findByRole("img").should("have.attr", "src", processedImagePath);
       });
 
-      it("should be able to import a project with a singular image", () => {
+      it("should be able to import a project with a singular image", function () {
         const baseURL = Cypress.config().baseUrl;
         const testURL = "/uploads/pork-carnitas.html";
         const fullTestURL = new URL(testURL, baseURL);

--- a/websites/portfolio/editor/cypress/e2e/pages.cy.ts
+++ b/websites/portfolio/editor/cypress/e2e/pages.cy.ts
@@ -1,25 +1,25 @@
-describe("Page Editor", () => {
-  describe("with a clean slate", () => {
-    it("should need authorization", () => {
+describe("Page Editor", function () {
+  describe("with a clean slate", function () {
+    it("should need authorization", function () {
       cy.resetData();
       cy.visit("/pages");
       cy.findByText("Sign in with Credentials");
     });
 
-    it("should need authorization when directly going to an edit page", () => {
+    it("should need authorization when directly going to an edit page", function () {
       cy.resetData("about-page");
       cy.visit("/pages/edit/about");
       cy.findByText("Sign in with Credentials");
     });
 
-    describe("when authenticated", () => {
-      beforeEach(() => {
+    describe("when authenticated", function () {
+      beforeEach(function () {
         cy.resetData();
         cy.visit("/pages");
         cy.fillSignInForm();
       });
 
-      it("should be able to add, edit, and remove a page", () => {
+      it("should be able to add, edit, and remove a page", function () {
         // Confirm initial empty state
         cy.findByText("There are no pages yet.");
 

--- a/websites/portfolio/editor/cypress/e2e/project.cy.ts
+++ b/websites/portfolio/editor/cypress/e2e/project.cy.ts
@@ -1,19 +1,19 @@
-describe("Single Project View", () => {
-  describe("with seven items", () => {
-    beforeEach(() => {
+describe("Single Project View", function () {
+  describe("with seven items", function () {
+    beforeEach(function () {
       cy.resetData("two-pages");
       cy.visit("/project/project-6");
     });
 
-    it("should display a project", () => {
+    it("should display a project", function () {
       cy.findByText("Project 6");
     });
 
-    it("should not need authorization", () => {
+    it("should not need authorization", function () {
       cy.findByText("Sign In");
     });
 
-    it("should be able to multiply ingredient amounts", () => {
+    it("should be able to multiply ingredient amounts", function () {
       cy.findByText("1 1/2 tsp salt");
       cy.findByText("Sprinkle 1/2 tsp salt in water");
       cy.findByLabelText("Multiply").type("2");
@@ -21,7 +21,7 @@ describe("Single Project View", () => {
       cy.findByText("Sprinkle 1 tsp salt in water");
     });
 
-    it("should be able to edit a project", () => {
+    it("should be able to edit a project", function () {
       cy.findByText("Edit").click();
 
       cy.fillSignInForm();
@@ -57,7 +57,7 @@ describe("Single Project View", () => {
       cy.findByText(new Date(projectDate + "Z").toLocaleString());
     });
 
-    it("should be able to delete the project", () => {
+    it("should be able to delete the project", function () {
       cy.findByText("Delete").click();
 
       // First click of the delete button should trigger a sign-in
@@ -83,7 +83,7 @@ describe("Single Project View", () => {
     });
   });
 
-  it("should have status 404 when project doesn't exist", () => {
+  it("should have status 404 when project doesn't exist", function () {
     cy.request({
       url: "/project/non-existent-project",
       failOnStatusCode: false,

--- a/websites/portfolio/editor/cypress/e2e/search.cy.ts
+++ b/websites/portfolio/editor/cypress/e2e/search.cy.ts
@@ -1,15 +1,15 @@
-describe("Search Page", () => {
-  describe("with seven items", () => {
-    beforeEach(() => {
+describe("Search Page", function () {
+  describe("with seven items", function () {
+    beforeEach(function () {
       cy.resetData("two-pages");
       cy.visit("/search");
     });
 
-    it("should not need authorization", () => {
+    it("should not need authorization", function () {
       cy.findByText("Sign In");
     });
 
-    it("should be able to find a single project by name", () => {
+    it("should be able to find a single project by name", function () {
       cy.findByLabelText("Query").type("Project 6");
       cy.findByRole("button", { name: "Submit" }).click();
 
@@ -50,7 +50,7 @@ describe("Search Page", () => {
         .should("have.text", "Project 5");
     });
 
-    it("should be able to find a project by ingredient", () => {
+    it("should be able to find a project by ingredient", function () {
       cy.findByLabelText("Query").type("sal");
       cy.findByRole("button", { name: "Submit" }).click();
 

--- a/websites/recipe-website/editor/cypress/e2e/edit.cy.ts
+++ b/websites/recipe-website/editor/cypress/e2e/edit.cy.ts
@@ -1,26 +1,26 @@
-describe("Recipe Edit View", () => {
-  describe("with seven items", () => {
-    beforeEach(() => {
+describe("Recipe Edit View", function () {
+  describe("with seven items", function () {
+    beforeEach(function () {
       cy.resetData("two-pages");
       cy.visit("/recipe/recipe-6/edit");
     });
 
-    it("should need authorization", () => {
+    it("should need authorization", function () {
       cy.findByText("Sign in with Credentials");
     });
 
-    it("should require authorization even when recipe doesn't exist", () => {
+    it("should require authorization even when recipe doesn't exist", function () {
       cy.visit({
         url: "/recipe/non-existent-recipe/edit",
       });
     });
 
-    describe("when authenticated", () => {
-      beforeEach(() => {
+    describe("when authenticated", function () {
+      beforeEach(function () {
         cy.fillSignInForm();
       });
 
-      it("should be able to edit a recipe", () => {
+      it("should be able to edit a recipe", function () {
         cy.findByText("Editing Recipe: Recipe 6");
 
         cy.findByText("Advanced").click();
@@ -52,7 +52,7 @@ describe("Recipe Edit View", () => {
         cy.findByText(new Date(recipeDate + "Z").toLocaleString());
       });
 
-      it("should be able to set a recipe image over another image", () => {
+      it("should be able to set a recipe image over another image", function () {
         cy.findByText("Editing Recipe: Recipe 6");
 
         // Image preview should be current image
@@ -94,7 +94,7 @@ describe("Recipe Edit View", () => {
           );
       });
 
-      it("should be able to set a recipe image on a recipe without an image", () => {
+      it("should be able to set a recipe image on a recipe without an image", function () {
         cy.visit("/recipe/recipe-5/edit");
         cy.findByText("Editing Recipe: Recipe 5");
 
@@ -137,7 +137,7 @@ describe("Recipe Edit View", () => {
           );
       });
 
-      it("should be able to remove an image", () => {
+      it("should be able to remove an image", function () {
         cy.findByText("Editing Recipe: Recipe 6");
 
         cy.findByRole("img");
@@ -153,7 +153,7 @@ describe("Recipe Edit View", () => {
         cy.findAllByLabelText("Remove Image").should("not.exist");
       });
 
-      it("should be able to preserve an image when editing", () => {
+      it("should be able to preserve an image when editing", function () {
         cy.findByText("Editing Recipe: Recipe 6");
 
         cy.findByRole("img");
@@ -184,7 +184,7 @@ describe("Recipe Edit View", () => {
         cy.findByLabelText("Remove Image");
       });
 
-      it("should have status 404 when recipe doesn't exist", () => {
+      it("should have status 404 when recipe doesn't exist", function () {
         cy.request({
           url: "/recipe/non-existent-recipe/edit",
           failOnStatusCode: false,

--- a/websites/recipe-website/editor/cypress/e2e/git.cy.ts
+++ b/websites/recipe-website/editor/cypress/e2e/git.cy.ts
@@ -1,6 +1,6 @@
-describe("Git content", () => {
-  describe("when empty", () => {
-    it("should indicate when the content directory is not tracked by git", () => {
+describe("Git content", function () {
+  describe("when empty", function () {
+    it("should indicate when the content directory is not tracked by git", function () {
       cy.resetData();
       cy.visit("/git");
       cy.fillSignInForm();
@@ -9,7 +9,7 @@ describe("Git content", () => {
       cy.findAllByText("Branches").should("not.exist");
     });
 
-    it("should be able to work with a git-tracked content directory", () => {
+    it("should be able to work with a git-tracked content directory", function () {
       cy.resetData();
       cy.initializeContentGit();
       cy.visit("/");

--- a/websites/recipe-website/editor/cypress/e2e/homepage.cy.ts
+++ b/websites/recipe-website/editor/cypress/e2e/homepage.cy.ts
@@ -1,19 +1,19 @@
-describe("Index Page", () => {
-  describe("when empty", () => {
-    beforeEach(() => {
+describe("Index Page", function () {
+  describe("when empty", function () {
+    beforeEach(function () {
       cy.resetData();
       cy.visit("/");
     });
 
-    it("should not need authorization", () => {
+    it("should not need authorization", function () {
       cy.findByText("Sign In");
     });
 
-    it("should inform the user if there are no recipes", () => {
+    it("should inform the user if there are no recipes", function () {
       cy.findByText("There are no recipes yet.");
     });
 
-    it("should be able to create and delete a recipe", () => {
+    it("should be able to create and delete a recipe", function () {
       const testRecipe = "Test Recipe";
 
       // We should start with no recipes
@@ -44,7 +44,7 @@ describe("Index Page", () => {
         .should("equal", 404);
     });
 
-    it("should be able to create recipes and see them in chronological order", () => {
+    it("should be able to create recipes and see them in chronological order", function () {
       cy.findByText("Sign In").click();
 
       cy.fillSignInForm();
@@ -62,13 +62,13 @@ describe("Index Page", () => {
     });
   });
 
-  describe("with just enough items for the front page", () => {
-    beforeEach(() => {
+  describe("with just enough items for the front page", function () {
+    beforeEach(function () {
       cy.resetData("front-page-only");
       cy.visit("/");
     });
 
-    it("should not display a link to the index", () => {
+    it("should not display a link to the index", function () {
       const allNames = [3, 2, 1].map((x) => `Recipe ${x}`);
 
       // Homepage should have latest three recipes
@@ -78,13 +78,13 @@ describe("Index Page", () => {
     });
   });
 
-  describe("with seven items", () => {
-    beforeEach(() => {
+  describe("with seven items", function () {
+    beforeEach(function () {
       cy.resetData("two-pages");
       cy.visit("/");
     });
 
-    it("should display the latest six recipes", () => {
+    it("should display the latest six recipes", function () {
       const allNames = [7, 6, 5, 4, 3, 2, 1].map((x) => `Recipe ${x}`);
 
       // Homepage should have latest three recipes

--- a/websites/recipe-website/editor/cypress/e2e/menus.cy.ts
+++ b/websites/recipe-website/editor/cypress/e2e/menus.cy.ts
@@ -1,25 +1,25 @@
-describe("Menu Editor", () => {
-  describe("with a clean slate", () => {
-    beforeEach(() => {
+describe("Menu Editor", function () {
+  describe("with a clean slate", function () {
+    beforeEach(function () {
       cy.resetData();
       cy.visit("/menus");
     });
 
-    it("should need authorization", () => {
+    it("should need authorization", function () {
       cy.findByText("Sign in with Credentials");
     });
 
-    it("should need authorization when directly going to edit the header", () => {
+    it("should need authorization when directly going to edit the header", function () {
       cy.visit("/menus/edit/header");
       cy.findByText("Sign in with Credentials");
     });
 
-    describe("when authenticated", () => {
-      beforeEach(() => {
+    describe("when authenticated", function () {
+      beforeEach(function () {
         cy.fillSignInForm();
       });
 
-      it("should be able to add to, edit, and clear the header nav", () => {
+      it("should be able to add to, edit, and clear the header nav", function () {
         // Add nav item to header
 
         cy.findByText("Header").click();
@@ -59,7 +59,7 @@ describe("Menu Editor", () => {
         cy.findAllByText("About").should("not.exist");
       });
 
-      it("should be able to add to, edit, and clear the footer nav", () => {
+      it("should be able to add to, edit, and clear the footer nav", function () {
         // Add nav item to footer
 
         cy.findByText("Footer").click();

--- a/websites/recipe-website/editor/cypress/e2e/new-recipe.cy.ts
+++ b/websites/recipe-website/editor/cypress/e2e/new-recipe.cy.ts
@@ -1,20 +1,20 @@
-describe("New Recipe View", () => {
-  describe("with the importable uploads fixture", () => {
-    beforeEach(() => {
+describe("New Recipe View", function () {
+  describe("with the importable uploads fixture", function () {
+    beforeEach(function () {
       cy.resetData("importable-uploads");
       cy.visit("/new-recipe");
     });
 
-    it("should need authentication", () => {
+    it("should need authentication", function () {
       cy.findByText("Sign in with Credentials");
     });
 
-    describe("when authenticated", () => {
-      beforeEach(() => {
+    describe("when authenticated", function () {
+      beforeEach(function () {
         cy.fillSignInForm();
       });
 
-      it("should be able to create a new recipe", () => {
+      it("should be able to create a new recipe", function () {
         cy.findByRole("heading", { name: "New Recipe" });
 
         const newRecipeTitle = "My New Recipe";
@@ -33,7 +33,7 @@ describe("New Recipe View", () => {
         cy.checkNamesInOrder([newRecipeTitle]);
       });
 
-      it("should trim pasted instructions", () => {
+      it("should trim pasted instructions", function () {
         cy.findByRole("heading", { name: "New Recipe" });
 
         const newRecipeTitle = "My New Recipe";
@@ -90,7 +90,7 @@ Have no number on three
         cy.findByText(`Have whitespace at the beginning and end`);
       });
 
-      it("should be able to paste ingredients with different bullet styles", () => {
+      it("should be able to paste ingredients with different bullet styles", function () {
         cy.findByRole("heading", { name: "New Recipe" });
 
         const newRecipeTitle = "My New Recipe";
@@ -146,7 +146,7 @@ Have no number on three
         );
       });
 
-      it("should be able to import a recipe", () => {
+      it("should be able to import a recipe", function () {
         const baseURL = Cypress.config().baseUrl;
         const testURL = "/uploads/katsudon.html";
         const fullTestURL = new URL(testURL, baseURL);
@@ -197,7 +197,7 @@ Have no number on three
         });
       });
 
-      it("should be able to import a recipe with an image", () => {
+      it("should be able to import a recipe with an image", function () {
         const baseURL = Cypress.config().baseUrl;
         const testURL = "/uploads/blackstone-nachos.html";
         const fullTestURL = new URL(testURL, baseURL);
@@ -280,7 +280,7 @@ Have no number on three
         cy.findByRole("img").should("have.attr", "src", processedImagePath);
       });
 
-      it("should be able to import a recipe with a singular image", () => {
+      it("should be able to import a recipe with a singular image", function () {
         const baseURL = Cypress.config().baseUrl;
         const testURL = "/uploads/pork-carnitas.html";
         const fullTestURL = new URL(testURL, baseURL);

--- a/websites/recipe-website/editor/cypress/e2e/pages.cy.ts
+++ b/websites/recipe-website/editor/cypress/e2e/pages.cy.ts
@@ -1,25 +1,25 @@
-describe("Page Editor", () => {
-  describe("with a clean slate", () => {
-    it("should need authorization", () => {
+describe("Page Editor", function () {
+  describe("with a clean slate", function () {
+    it("should need authorization", function () {
       cy.resetData();
       cy.visit("/pages");
       cy.findByText("Sign in with Credentials");
     });
 
-    it("should need authorization when directly going to an edit page", () => {
+    it("should need authorization when directly going to an edit page", function () {
       cy.resetData("about-page");
       cy.visit("/pages/edit/about");
       cy.findByText("Sign in with Credentials");
     });
 
-    describe("when authenticated", () => {
-      beforeEach(() => {
+    describe("when authenticated", function () {
+      beforeEach(function () {
         cy.resetData();
         cy.visit("/pages");
         cy.fillSignInForm();
       });
 
-      it("should be able to add, edit, and remove a page", () => {
+      it("should be able to add, edit, and remove a page", function () {
         // Confirm initial empty state
         cy.findByText("There are no pages yet.");
 

--- a/websites/recipe-website/editor/cypress/e2e/recipe.cy.ts
+++ b/websites/recipe-website/editor/cypress/e2e/recipe.cy.ts
@@ -1,20 +1,20 @@
-describe("Single Recipe View", () => {
-  describe("with seven items", () => {
-    beforeEach(() => {
+describe("Single Recipe View", function () {
+  describe("with seven items", function () {
+    beforeEach(function () {
       cy.resetData("two-pages");
       cy.visit("/recipe/recipe-6");
     });
 
-    it("should display a recipe", () => {
+    it("should display a recipe", function () {
       cy.findByText("Recipe 6", { selector: "h1" });
       cy.get("title").should("contain.text", "Recipe 6");
     });
 
-    it("should not need authorization", () => {
+    it("should not need authorization", function () {
       cy.findByText("Sign In");
     });
 
-    it("should be able to multiply ingredient amounts", () => {
+    it("should be able to multiply ingredient amounts", function () {
       cy.findByText("1 1/2 tsp salt");
       cy.findByText("Sprinkle 1/2 tsp salt in water");
       cy.findByLabelText("Multiply").type("2");
@@ -22,7 +22,7 @@ describe("Single Recipe View", () => {
       cy.findByText("Sprinkle 1 tsp salt in water");
     });
 
-    it("should be able to edit a recipe", () => {
+    it("should be able to edit a recipe", function () {
       cy.findByText("Edit").click();
 
       cy.fillSignInForm();
@@ -58,7 +58,7 @@ describe("Single Recipe View", () => {
       cy.findByText(new Date(recipeDate + "Z").toLocaleString());
     });
 
-    it("should be able to delete the recipe", () => {
+    it("should be able to delete the recipe", function () {
       cy.findByText("Delete").click();
 
       // First click of the delete button should trigger a sign-in
@@ -84,7 +84,7 @@ describe("Single Recipe View", () => {
     });
   });
 
-  it("should have status 404 when recipe doesn't exist", () => {
+  it("should have status 404 when recipe doesn't exist", function () {
     cy.request({
       url: "/recipe/non-existent-recipe",
       failOnStatusCode: false,

--- a/websites/recipe-website/editor/cypress/e2e/search.cy.ts
+++ b/websites/recipe-website/editor/cypress/e2e/search.cy.ts
@@ -1,15 +1,15 @@
-describe("Search Page", () => {
-  describe("with seven items", () => {
-    beforeEach(() => {
+describe("Search Page", function () {
+  describe("with seven items", function () {
+    beforeEach(function () {
       cy.resetData("two-pages");
       cy.visit("/search");
     });
 
-    it("should not need authorization", () => {
+    it("should not need authorization", function () {
       cy.findByText("Sign In");
     });
 
-    it("should be able to find a single recipe by name", () => {
+    it("should be able to find a single recipe by name", function () {
       cy.findByLabelText("Query").type("Recipe 6");
       cy.findByRole("button", { name: "Submit" }).click();
 
@@ -50,7 +50,7 @@ describe("Search Page", () => {
         .should("have.text", "Recipe 5");
     });
 
-    it("should be able to find a recipe by ingredient", () => {
+    it("should be able to find a recipe by ingredient", function () {
       cy.findByLabelText("Query").type("sal");
       cy.findByRole("button", { name: "Submit" }).click();
 


### PR DESCRIPTION
When upgrading to eslint 9, I used a boilerplate for getting NextJS configured. `eslint-plugin-mocha` was removed in the process, and this PR re-introduces it with the new eslint setup. This PR also fixes all issues which came up after adding the new rules, which was all switching from arrow functions to normal anonymous functions in hooks and tests.