### PR TITLE
Fix images using plain img tag

### DIFF
--- a/websites/recipe-website/common/components/List/index.tsx
+++ b/websites/recipe-website/common/components/List/index.tsx
@@ -38,6 +38,7 @@ export function RecipeListItem({
               width={400}
               height={400}
               className="w-full h-full object-cover group-hover:scale-105 transition duration-300"
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
             />
           )}
         </div>

--- a/websites/recipe-website/common/components/RecipeImage/index.tsx
+++ b/websites/recipe-website/common/components/RecipeImage/index.tsx
@@ -1,10 +1,10 @@
+/* eslint-disable @next/next/no-img-element */
 import { join } from "path";
 import { getContentDirectory } from "content-engine/fs/getContentDirectory";
 import {
   TransformedStaticImageProps,
   getStaticImageProps,
 } from "next-static-image/src";
-import Image from "next/image";
 import { getRecipeUploadPath } from "../../controller/filesystemDirectories";
 
 const localOutputDirectory = join(getContentDirectory(), "transformed-images");
@@ -47,10 +47,6 @@ export async function getTransformedRecipeImageProps({
 export async function RecipeImage(inputProps: TransformedStaticImageProps) {
   const image = await getTransformedRecipeImageProps(inputProps);
   if (image) {
-    return (
-      <Image {...image.props} alt={inputProps.alt} unoptimized={true}>
-        {null}
-      </Image>
-    );
+    return <img {...image.props} alt={inputProps.alt} />;
   }
 }

--- a/websites/recipe-website/common/components/View/index.tsx
+++ b/websites/recipe-website/common/components/View/index.tsx
@@ -1,7 +1,7 @@
+/* eslint-disable @next/next/no-img-element */
 import { Recipe } from "../../controller/types";
 
 import Markdown from "component-library/components/Markdown";
-import Image from "next/image";
 import { getTransformedRecipeImageProps } from "../RecipeImage";
 import { Ingredients, MultipliedServings, MultiplierInput } from "./Multiplier";
 import { InfoCard } from "./shared";
@@ -57,11 +57,7 @@ export async function RecipeView({
           <div className="container mx-auto lg:flex lg:flex-row justify-center print:w-full print:max-w-full">
             <div className="aspect-ratio-[16/10] w-full h-96 lg:max-w-96 lg:mr-4 print:hidden relative">
               {recipeImageProps && (
-                <Image
-                  {...recipeImageProps.props}
-                  alt="Heading image"
-                  unoptimized={true}
-                />
+                <img {...recipeImageProps.props} alt="Heading image" />
               )}
               {video && (
                 <VideoPlayer

--- a/websites/recipe-website/editor/cypress/e2e/edit.cy.ts
+++ b/websites/recipe-website/editor/cypress/e2e/edit.cy.ts
@@ -141,7 +141,7 @@ describe("Recipe Edit View", function () {
           .should(
             "have.attr",
             "src",
-            "/image/uploads/recipe/recipe-6/uploads/recipe-6-test-image-alternate.png/recipe-6-test-image-alternate-w828q75.webp",
+            "/image/uploads/recipe/recipe-6/uploads/recipe-6-test-image-alternate.png/recipe-6-test-image-alternate-w3840q75.webp",
           );
       });
 
@@ -184,7 +184,7 @@ describe("Recipe Edit View", function () {
           .should(
             "have.attr",
             "src",
-            "/image/uploads/recipe/recipe-5/uploads/recipe-6-test-image-alternate.png/recipe-6-test-image-alternate-w828q75.webp",
+            "/image/uploads/recipe/recipe-5/uploads/recipe-6-test-image-alternate.png/recipe-6-test-image-alternate-w3840q75.webp",
           );
       });
 

--- a/websites/recipe-website/editor/cypress/e2e/new-recipe.cy.ts
+++ b/websites/recipe-website/editor/cypress/e2e/new-recipe.cy.ts
@@ -36,9 +36,24 @@ describe("New Recipe View", function () {
         // Check if the image is resized correctly
         cy.findByRole("img").should(($img) => {
           const img = $img[0] as HTMLImageElement;
-          // Adjust dimensions to the expected size of your image
-          expect(img.naturalWidth).to.eq(566);
-          expect(img.naturalHeight).to.eq(566);
+          expect(img.src).to.eq(
+            new URL(
+              "/image/uploads/recipe/blackstone-griddle-grilled-nachos/uploads/recipe-imported-image-566x566.png/recipe-imported-image-566x566-w3840q75.webp",
+              baseURL,
+            ).href,
+          );
+          expect(img.srcset).to.eq(
+            [
+              "/image/uploads/recipe/blackstone-griddle-grilled-nachos/uploads/recipe-imported-image-566x566.png/recipe-imported-image-566x566-w640q75.webp 640w",
+              "/image/uploads/recipe/blackstone-griddle-grilled-nachos/uploads/recipe-imported-image-566x566.png/recipe-imported-image-566x566-w750q75.webp 750w",
+              "/image/uploads/recipe/blackstone-griddle-grilled-nachos/uploads/recipe-imported-image-566x566.png/recipe-imported-image-566x566-w828q75.webp 828w",
+              "/image/uploads/recipe/blackstone-griddle-grilled-nachos/uploads/recipe-imported-image-566x566.png/recipe-imported-image-566x566-w1080q75.webp 1080w",
+              "/image/uploads/recipe/blackstone-griddle-grilled-nachos/uploads/recipe-imported-image-566x566.png/recipe-imported-image-566x566-w1200q75.webp 1200w",
+              "/image/uploads/recipe/blackstone-griddle-grilled-nachos/uploads/recipe-imported-image-566x566.png/recipe-imported-image-566x566-w1920q75.webp 1920w",
+              "/image/uploads/recipe/blackstone-griddle-grilled-nachos/uploads/recipe-imported-image-566x566.png/recipe-imported-image-566x566-w2048q75.webp 2048w",
+              "/image/uploads/recipe/blackstone-griddle-grilled-nachos/uploads/recipe-imported-image-566x566.png/recipe-imported-image-566x566-w3840q75.webp 3840w",
+            ].join(", "),
+          );
         });
       });
 
@@ -207,7 +222,7 @@ describe("New Recipe View", function () {
         cy.findByRole("heading", { name: newRecipeTitle }).should("not.exist");
       });
 
-      it("should be able to add a new recipe with a video", function () {
+      it.only("should be able to add a new recipe with a video", function () {
         cy.findByRole("heading", { name: "New Recipe" });
 
         const newRecipeTitle = "My New Recipe with Video";
@@ -243,7 +258,7 @@ describe("New Recipe View", function () {
 
         // Test VideoTime component's timestamp link
         cy.findByText("10s").click();
-        cy.get("video", { timeout: 8000 }).should(($video) => {
+        cy.get("video", { timeout: 5000 }).should(($video) => {
           expect($video[0].currentTime).to.be.closeTo(10, 1); // Adjust the time as per your test video
         });
       });

--- a/websites/recipe-website/editor/cypress/e2e/new-recipe.cy.ts
+++ b/websites/recipe-website/editor/cypress/e2e/new-recipe.cy.ts
@@ -222,7 +222,7 @@ describe("New Recipe View", function () {
         cy.findByRole("heading", { name: newRecipeTitle }).should("not.exist");
       });
 
-      it.only("should be able to add a new recipe with a video", function () {
+      it("should be able to add a new recipe with a video", function () {
         cy.findByRole("heading", { name: "New Recipe" });
 
         const newRecipeTitle = "My New Recipe with Video";


### PR DESCRIPTION
Turns out `<Image unoptimized={true}` doesn't properly use all of the static props, most notably `srcSet`. That and adding a `sizes` gives us more robust responsive images.

Also drops `runningResizes` since it causes missing image errors. A new mechanism will have to replace it, but removing it makes everything work consistently, albeit less efficiently.