### PR TITLE
Remove flaky video link test

### DIFF
--- a/websites/recipe-website/editor/cypress/e2e/edit.cy.ts
+++ b/websites/recipe-website/editor/cypress/e2e/edit.cy.ts
@@ -49,11 +49,7 @@ describe("Recipe Edit View", function () {
         cy.findByText("Recipe 6", { selector: "h1" });
         cy.get("video").should("exist");
 
-        // Test VideoTime component's timestamp link
-        cy.findByText("10s").click();
-        cy.get("video", { timeout: 10000 }).should(($video) => {
-          expect($video[0].currentTime).to.be.closeTo(10, 1); // Adjust the time as per your test video
-        });
+        // TODO: Test VideoTime component's timestamp link
       });
 
       it("should be able to edit a recipe", function () {

--- a/websites/recipe-website/editor/cypress/e2e/new-recipe.cy.ts
+++ b/websites/recipe-website/editor/cypress/e2e/new-recipe.cy.ts
@@ -256,11 +256,7 @@ describe("New Recipe View", function () {
         cy.findByRole("heading", { name: newRecipeTitle });
         cy.get("video").should("exist");
 
-        // Test VideoTime component's timestamp link
-        cy.findByText("10s").click();
-        cy.get("video", { timeout: 5000 }).should(($video) => {
-          expect($video[0].currentTime).to.be.closeTo(10, 1); // Adjust the time as per your test video
-        });
+        // TODO: Test VideoTime component's timestamp link
       });
 
       it("should be able to create a new recipe", function () {


### PR DESCRIPTION
Testing the video link breaks, especially in headless tests, seemingly due to browser-specific issues related to seeking in videos. This PR simply stubs those tests for a fix later on down the line.