### PR TITLE
Fix importing images with GET parameters

### DIFF
--- a/websites/recipe-website/common/controller/writeUpload.ts
+++ b/websites/recipe-website/common/controller/writeUpload.ts
@@ -22,7 +22,7 @@ export async function getUploadInfo({
   existingFile,
 }: {
   file?: File;
-  clearFile: boolean;
+  clearFile?: boolean;
   fileImportUrl?: string;
   existingFile?: string;
 }): Promise<RecipeFileData | undefined> {
@@ -33,8 +33,10 @@ export async function getUploadInfo({
     return undefined;
   }
   if (fileImportUrl) {
+    const url = new URL(fileImportUrl);
+    const basenameWithoutParams = basename(url.pathname);
     return {
-      fileName: basename(fileImportUrl),
+      fileName: basenameWithoutParams,
       fileImportUrl,
     };
   }

--- a/websites/recipe-website/editor/cypress/e2e/new-recipe.cy.ts
+++ b/websites/recipe-website/editor/cypress/e2e/new-recipe.cy.ts
@@ -442,6 +442,91 @@ Have no number on three
         });
       });
 
+      it("should be able to import a recipe with an image with GET params", function () {
+        const baseURL = Cypress.config().baseUrl;
+        const testURL = "/uploads/blackstone-nachos-with-params.html";
+        const fullTestURL = new URL(testURL, baseURL);
+        cy.findByLabelText("Import from URL").type(fullTestURL.href);
+        cy.findByRole("button", { name: "Import" }).click();
+        cy.url().should(
+          "equal",
+          new URL(
+            `/new-recipe?import=${encodeURIComponent(fullTestURL.href)}`,
+            baseURL,
+          ).href,
+        );
+
+        // Stay within the recipe form to minimize matching outside
+        cy.get("#recipe-form").within(() => {
+          // Verify top-level fields, i.e. name and description
+          cy.get('[name="name"]').should(
+            "have.value",
+            "Blackstone Griddle Grilled Nachos",
+          );
+          cy.get('[name="description"]').should(
+            "have.value",
+            "*Imported from [http://localhost:3000/uploads/blackstone-nachos-with-params.html](http://localhost:3000/uploads/blackstone-nachos-with-params.html)*\n\n---\n\nWho doesn’t love nachos? Jazz up your nacho routine with these super-tasty Blackstone Nachos Supreme. Made effortlessly on your Blackstone Griddle, there’s nothing like this towering pile of crispy chips and delish toppings for your next snack attack.",
+          );
+
+          // Verify first ingredient
+          cy.get('[name="ingredients[0].ingredient"]').should(
+            "have.value",
+            `Olive Oil <Multiplyable baseNumber="1" /> tablespoon`,
+          );
+
+          // Verify last ingredient
+          cy.get('[name="ingredients[9].ingredient"]').should(
+            "have.value",
+            `Lettuce, Shredded <Multiplyable baseNumber="1/2" /> cup`,
+          );
+
+          // Verify empty string ingredient from import was ignored
+          cy.get('[name="ingredients[10].ingredient"]').should("not.exist");
+
+          // Verify first instruction
+          cy.get('[name="instructions[0].name"]').should("have.value", "");
+          cy.get('[name="instructions[0].text"]').should(
+            "have.value",
+            "Preheat the Blackstone Flat Top Griddle to medium heat.",
+          );
+
+          // Image preview should be external link to image we will import
+          cy.findByRole("img").should(
+            "have.attr",
+            "src",
+            new URL(
+              "/uploads/recipe-imported-image-566x566.png?param=value",
+              baseURL,
+            ).href,
+          );
+        });
+
+        cy.findByText("Submit").click();
+
+        // Ensure we're on the view page and not the new-recipe page
+        cy.findByLabelText("Multiply", { timeout: 10000 });
+
+        // Image should be newly created from the import's source
+        const processedImagePath =
+          "/image/uploads/recipe/blackstone-griddle-grilled-nachos/uploads/recipe-imported-image-566x566.png/recipe-imported-image-566x566-w3840q75.webp";
+
+        cy.findByRole("img").should("have.attr", "src", processedImagePath);
+
+        cy.request({
+          url: processedImagePath,
+        })
+          .its("status")
+          .should("equal", 200);
+
+        // Ensure resulting edit page works
+
+        cy.findByText("Edit").click();
+
+        cy.findByText("Editing Recipe: Blackstone Griddle Grilled Nachos");
+
+        cy.findByRole("img").should("have.attr", "src", processedImagePath);
+      });
+
       it("should be able to import a recipe with an image", function () {
         const baseURL = Cypress.config().baseUrl;
         const testURL = "/uploads/blackstone-nachos.html";

--- a/websites/recipe-website/editor/cypress/fixtures/test-content/importable-uploads/uploads/blackstone-nachos-with-params.html
+++ b/websites/recipe-website/editor/cypress/fixtures/test-content/importable-uploads/uploads/blackstone-nachos-with-params.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<html lang="en-US">
+  <body>
+    <script type="application/ld+json">
+      {
+        "@context": "http:\/\/schema.org",
+        "@type": "Recipe",
+        "name": "Blackstone Griddle Grilled Nachos",
+        "author": { "@type": "Person", "name": "Sherry Ronning" },
+        "datePublished": "2022-01-06",
+        "recipeYield": 10,
+        "description": "Who doesn\u2019t love nachos? Jazz up your nacho routine with these super-tasty Blackstone Nachos Supreme. Made effortlessly on your Blackstone Griddle, there\u2019s nothing like this towering pile of crispy chips and delish toppings for your next snack attack.",
+        "image": [
+          "http:\/\/localhost:3000\/uploads\/recipe-imported-image-566x566.png?param=value",
+          "http:\/\/localhost:3000\/uploads\/2021-11-28_0107-scaled-720x540.png?param=value",
+          "http:\/\/localhost:3000\/uploads\/2021-11-28_0107-scaled-540x720.png?param=value",
+          "http:\/\/localhost:3000\/uploads\/2021-11-28_0107-scaled-720x405.png?param=value",
+          "http:\/\/localhost:3000\/uploads\/2021-11-28_0107-scaled-735x1100.png?param=value"
+        ],
+        "recipeCategory": "Blackstone Griddle Recipes",
+        "recipeCuisine": "American",
+        "prepTime": "PT5M",
+        "cookTime": "PT5M",
+        "performTime": "PT7M",
+        "totalTime": "PT12M",
+        "recipeIngredient": [
+          "Olive Oil                      1 tablespoon",
+          "Ground Beef               1 lb",
+          "Taco Seasoning          2 tablespoons",
+          "Tortilla Strips               12 ounces",
+          "Water                          2 tablespoons",
+          "Shredded Cheese      2 cups",
+          "Tomato, Diced            1\/2 cup",
+          "Peppers, Bell              1\/4 cup",
+          "Sour Cream                 2 tablespoons",
+          "Lettuce, Shredded     1\/2 cup",
+          ""
+        ],
+        "recipeInstructions": [
+          {
+            "@type": "HowToStep",
+            "text": "Preheat the Blackstone Flat Top Griddle to medium heat.",
+            "position": 1,
+            "name": "Preheat the Blackstone Flat Top Griddle to medium...",
+            "url": "https:\/\/frommichigantothetable.com\/blackstone-nachos\/#mv_create_158_1"
+          },
+          {
+            "@type": "HowToStep",
+            "text": "Prepare your diced tomatoes, peppers and lettuce.",
+            "position": 2,
+            "name": "Prepare your diced tomatoes, peppers and lettuce.",
+            "url": "https:\/\/frommichigantothetable.com\/blackstone-nachos\/#mv_create_158_2"
+          },
+          {
+            "@type": "HowToStep",
+            "text": "As the Blackstone Griddle is heating up, apply the olive oil and spread with a griddle spatula.",
+            "position": 3,
+            "name": "As the Blackstone Griddle is heating up, apply...",
+            "url": "https:\/\/frommichigantothetable.com\/blackstone-nachos\/#mv_create_158_3"
+          },
+          {
+            "@type": "HowToStep",
+            "text": "When the griddle is hot and nearly smoking, add ground hamburger to the griddle. Cook the ground burger, breaking it up as you go, until it is in small pieces and no longer pink inside.",
+            "position": 4,
+            "name": "When the griddle is hot and nearly smoking,...",
+            "url": "https:\/\/frommichigantothetable.com\/blackstone-nachos\/#mv_create_158_4"
+          },
+          {
+            "@type": "HowToStep",
+            "text": "Make sure to separate as much of the ground beef grease from the cooked burger as possible before adding the taco seasoning. Push the excess grease into the grease trap.",
+            "position": 5,
+            "name": "Make sure to separate as much of the...",
+            "url": "https:\/\/frommichigantothetable.com\/blackstone-nachos\/#mv_create_158_5"
+          },
+          {
+            "@type": "HowToStep",
+            "text": "Top the cooked burger with the taco seasoning. Add a squirt of water to help combine the ground beef and taco seasoning,",
+            "position": 6,
+            "name": "Top the cooked burger with the taco seasoning....",
+            "url": "https:\/\/frommichigantothetable.com\/blackstone-nachos\/#mv_create_158_6"
+          },
+          {
+            "@type": "HowToStep",
+            "text": "When the meat mixture is cooked, place tortilla chips on a prepared baking sheet pan or serving dish lined with parchment paper.",
+            "position": 7,
+            "name": "When the meat mixture is cooked, place tortilla...",
+            "url": "https:\/\/frommichigantothetable.com\/blackstone-nachos\/#mv_create_158_7"
+          },
+          {
+            "@type": "HowToStep",
+            "text": "Top the tortilla chips with the hot beef mixture, and the shredded cheese.",
+            "position": 8,
+            "name": "Top the tortilla chips with the hot beef...",
+            "url": "https:\/\/frommichigantothetable.com\/blackstone-nachos\/#mv_create_158_8"
+          },
+          {
+            "@type": "HowToStep",
+            "text": "If desired place the whole sheet pan with the chips, burger and cheese onto the the hot Blackstone Griddle and cover with a large dome lid for about 2 - 3 minutes to melt the cheese.",
+            "position": 9,
+            "name": "If desired place the whole sheet pan with...",
+            "url": "https:\/\/frommichigantothetable.com\/blackstone-nachos\/#mv_create_158_9"
+          },
+          {
+            "@type": "HowToStep",
+            "text": "Choose your desired toppings.  Sprinkle the toppings like chopped bell peppers, diced tomatoes, shredded lettuce, and of course, a dollop of sour cream.",
+            "position": 10,
+            "name": "Choose your desired toppings. Sprinkle the toppings like...",
+            "url": "https:\/\/frommichigantothetable.com\/blackstone-nachos\/#mv_create_158_10"
+          },
+          {
+            "@type": "HowToStep",
+            "text": "Serve hot and make sure to have a variety of side, if possible, that your guests will like.",
+            "position": 11,
+            "name": "Serve hot and make sure to have a...",
+            "url": "https:\/\/frommichigantothetable.com\/blackstone-nachos\/#mv_create_158_11"
+          }
+        ],
+        "video": {
+          "@type": "VideoObject",
+          "name": "Nachos on the Blackstone Griddle",
+          "description": "The best part about this Blackstone Griddle Nachos recipe is making it on a griddle! Scale it up to feed a crowd and cook a massive pile of nachos supreme all at once or keep the recipe as it is and serve a handful of people. Gather your ingredients, fire up your outdoor griddle, and let\u2019s get cooking!  Who doesn\u2019t love nachos? Jazz up your nacho routine with these super-tasty Blackstone Nachos Supreme. Made effortlessly on your Blackstone Griddle, there\u2019s nothing like this towering pile of crispy chips and delish toppings for your next snack attack.  \n\n#tailgating #blackstone #nacho #nachos #blackstonegriddle \n\nGET THE FULL RECIPE \u2b07\ufe0f \u2b07\ufe0f \n\u2705 Blackstone Griddle Nacho Supreme: \nhttps:\/\/frommichigantothetable.com\/blackstone-nachos\/\n \n*SUBSCRIBE TO MY CHANNEL* https:\/\/www.youtube.com\/c\/SherryRonningFromMichiganToTheTable =========================================================================== \nWANT MORE BLACKSTONE GRIDDLE RECIPES??? \nClick here to get more Blackstone recipes: https:\/\/frommichigantothetable.com\/blackstone-griddle-recipes\/ \n\n\u2747\ufe0f Check From Michigan To The Table out on... \nWEBSITE: https:\/\/frommichigantothetable.com\/ \nFACEBOOK: https:\/\/fb.me\/frommichigantothetable\/ \nFACEBOOK GROUP: www.facebook.com\/groups\/blackstonegriddlelovers\/ PINTEREST: https:\/\/www.pinterest.com\/sherryronning\/ \nINSTAGRAM: https:\/\/www.instagram.com\/frommichigan2019\/ \n\n\u2b07\ufe0f PRODUCTS MENTIONED \u2b07\ufe0f \nAs an Amazon Associate, I earn from qualifying purchases.  This page contains affiliate links.  Click on the highlighted text in a post to explore a product.  If you purchase through one of them, I will receive a commission (at no additional cost to you).  I ONLY EVER ENDORSE PRODUCTS THAT I TRULY LOVE.  Thank you for your support!\n\nBlackstone 5-piece accessories set\nhttps:\/\/www.amazon.com\/gp\/product\/B00DYN0474?&linkCode=ll1&tag=sherryronni0f-20&linkId=b19705d0293cded880d92a062ad69b74&language=en_US&ref_=as_li_ss_tl\n\n36 inch Blackstone Griddle\nhttps:\/\/www.amazon.com\/Blackstone-Outdoor-Grill-Griddle-Station\/dp\/B00DYN0438?crid=JOZCCXJG0AV4&keywords=blackstone%2Bgriddle%2B36%2Binch&qid=1650842617&sprefix=Blackstone%2Bgriddle%2Caps%2C169&sr=8-5&th=1&linkCode=ll1&tag=sherryronni0f-20&linkId=2cf13655f02fba210b2f6e47ee857560&language=en_US&ref_=as_li_ss_tl\n\n\nINSTRUCTIONS\nHow to Make Nachos Supreme\nPreheat your Blackstone to medium heat. Apply a thin layer of your favorite cooking oil (recommend olive oil) to the griddle surface and let it get good and hot. When the griddle is hot and nearly smoking, add ground beef to the griddle. Cook the ground beef, breaking it up as you go, until it is no longer pink inside. Make sure to separate as much of the burger grease from the cooked burger as possible before adding the taco seasoning. Push the excess grease into the grease trap. Toss in a couple tablespoons of taco seasoning on top of the cooked burger. Add a squirt of water to help combine the ground beef and taco seasoning, if needed. Once the taco meat is cooked, place tortilla chips on a prepared baking sheet pan or serving dish. Do this by laying a piece of parchment paper or aluminum foil onto the baking sheet and spreading a single layer of tortilla chips across the full sheet pan. Top the tortilla chips with the hot ground beef mixture, and the shredded Mexican cheese blend. If desired place the whole sheet pan with the chips, burger and cheese onto the the hot Blackstone Griddle and cover with a dome lid for about 2 - 3 minutes to melt the cheese. By doing this you are creating an oven affect and making baked nachos.\n\nWhat is the Best Way to Layer Nachos?\nLayering nachos supreme is completely customizable. Sprinkle the toppings like diced bell peppers, chopped tomatoes, and of course, a dollop of sour cream. Crunchy shredded lettuce adds a nice touch to these towering nachos. Serve hot and make sure to have a variety of side that your guests will like. \n\nVariations on this Nachos Recipe\nThis griddle grilled nachos recipe is so super easy to customize! Have fun with all your favorite toppings, including:\n\u00b7      Refried beans\n\u00b7      Sliced green olives or black olives,\n\u00b7      Pickled jalapenos\n\u00b7      Pico de Gallo\n\u00b7      Your favorite salsa\n\u00b7      Hot sauce, nacho cheese sauce, lime wedges, chopped onion, different shredded cheese combinations, fresh cilantro, \n\u00b7      And more!",
+          "thumbnailUrl": "https:\/\/i.ytimg.com\/vi\/8p-YMej-_Pg\/hqdefault.jpg",
+          "contentUrl": "https:\/\/www.youtube.com\/watch?v=8p-YMej-_Pg",
+          "duration": "PT9M33S",
+          "uploadDate": "2022-09-26T04:06:22Z"
+        },
+        "keywords": "Blackstone Nachos Supreme, Blackstone Nachos, Blackstone Griddle Nachos, Griddle Nachos, Grilled Nachos, Loaded Nachos, How to Make Nachos Supreme, What is the Best Way to Layer Nachos?",
+        "suitableForDiet": "GlutenFreeDiet",
+        "nutrition": {
+          "@type": "NutritionInformation",
+          "calories": "401 calories",
+          "carbohydrateContent": "25 grams carbohydrates",
+          "cholesterolContent": "64 milligrams cholesterol",
+          "fatContent": "24 grams fat",
+          "fiberContent": "2 grams fiber",
+          "proteinContent": "20 grams protein",
+          "saturatedFatContent": "9 grams saturated fat",
+          "servingSize": "1",
+          "sodiumContent": "425 milligrams sodium",
+          "sugarContent": "1 grams sugar",
+          "transFatContent": "1 grams trans fat",
+          "unsaturatedFatContent": "13 grams unsaturated fat"
+        },
+        "aggregateRating": {
+          "@type": "AggregateRating",
+          "ratingValue": 4.5,
+          "reviewCount": "13"
+        },
+        "url": "https:\/\/frommichigantothetable.com\/blackstone-nachos\/"
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This PR fixes image imports on recipes which have GET parameters in their image URLs, downloading with params but saving as the filename alone. `new URL` is used to trim the params.