### PR TITLE
Add docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+.git
+.gitignore
+*.md
+dist
+.next
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+websites/recipe-website/editor/content

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:20-slim AS base
+
+# Enable pnpm
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+# Copy the project
+COPY . /app
+WORKDIR /app
+
+ENV INITIAL_ADMIN_EMAIL=admin@example.com
+ENV INITIAL_ADMIN_PASSWORD=password 
+
+# Build the editor app
+WORKDIR /app/websites/recipe-website/editor
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+RUN pnpm dlx auth secret
+RUN pnpm run build
+
+RUN pnpm run create-user --email="${INITIAL_ADMIN_EMAIL}" --password="${INITIAL_ADMIN_PASSWORD}"
+
+# Run the editor app server
+EXPOSE 3000
+CMD [ "pnpm", "run", "--filter=recipe-editor", "start" ]

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,3 +12,15 @@ packages:
   - packages/pages-collection
   - packages/menus-collection
   - packages/content-engine
+
+onlyBuiltDependencies:
+  - cypress
+  - netlify-cli
+  - sharp
+  - parcel/watcher
+  - bcrypt
+  - cbor-extract
+  - esbuild
+  - lmdb
+  - msgpackr-extract
+  - unix-dgram

--- a/websites/recipe-website/README.md
+++ b/websites/recipe-website/README.md
@@ -48,3 +48,23 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 The editor app has a Cypress e2e test suite that can run against the development server or the optimized production build via two sets of scripts: `e2e-dev` and `e2e-start` both with `:headless` variants.
 
 `e2e-dev` is helpful for rapid development, while `e2e-start` runs faster and is more reflective of production. Remember to run `build` after any changes for those to apply to `e2e-start`!
+
+## Docker
+
+The root of the monorepo is equipped with a basic Dockerfile which enables running this editor.
+
+Use the following command in the root of this repo to build a Docker image:
+
+```bash
+docker build -t content-engine-recipe-website .
+```
+
+Now you can run the image:
+
+```bash
+docker run --name recipe-editor -p 3000:3000 content-engine-recipe-website:latest
+```
+
+And now you should be able to access the editor at `localhost:3000` with the baked-in account `admin@example.com`/`password`
+
+This is a very basic container setup and currently cannot be recommended for a production deploy.

--- a/websites/recipe-website/editor/scripts/create-user.mjs
+++ b/websites/recipe-website/editor/scripts/create-user.mjs
@@ -3,17 +3,37 @@ import { mkdir, writeFile } from "fs/promises";
 import { resolve } from "path";
 import { read } from "read";
 import process from "node:process";
+import { parseArgs } from "node:util";
 
-async function createUser() {
+const options = {
+  email: {
+    type: "string",
+  },
+  password: {
+    type: "string",
+  },
+};
+
+async function getInput() {
+  // If the user provides an email and password via command line, use them
+  const { values } = parseArgs({ options });
+  if (values.email) {
+    return { email: values.email, password: values.password || "password" };
+  }
+  // Otherwise, prompt the user for an email and password
   const email = await read({ prompt: "Enter an email: " });
-  const passwordPromise = read({
+  const password = await read({
     prompt: "Enter a password: ",
     silent: true,
     replace: "*",
   });
+  return { email, password };
+}
 
+async function createUser() {
+  const inputPromise = getInput();
   const salt = await genSalt();
-  const password = await passwordPromise;
+  const { email, password } = await inputPromise;
   const hashedPassword = await hash(password, salt);
   const userData = { email, password: hashedPassword };
   const usersDir = resolve(process.env.CONTENT_DIRECTORY || "content", "users");


### PR DESCRIPTION
This PR adds a very basic `Dockerfile` to the root of the project, enabling the use of Docker images to run the recipe editor.

Currently, this is an overly simple way to run the recipe editor (the most developed project in the monorepo) from the root mostly for dev and test purposes. It'll be built up more in the future.