### PR TITLE
Do not change numbers when not multiplying

### DIFF
--- a/websites/recipe-website/common/components/View/Multiplier/Multiplyable/index.tsx
+++ b/websites/recipe-website/common/components/View/Multiplier/Multiplyable/index.tsx
@@ -20,23 +20,23 @@ enum MultiplyableInputTypes {
 }
 
 export function Multiplyable({ baseNumber }: { baseNumber: string | number }) {
-  const input = useMemo(() => getFraction(baseNumber), [baseNumber]);
+  const fraction = useMemo(() => getFraction(baseNumber), [baseNumber]);
   const inputType =
     typeof baseNumber === "string" && baseNumber.includes(".")
       ? MultiplyableInputTypes.DECIMAL
       : MultiplyableInputTypes.FRACTION;
   const [{ multiplier }] = useMultiplier();
 
-  const displayNumber = multiplier
-    ? input && multiplier.mul(input).simplify(0.01)
-    : input;
+  const displayNumber =
+    fraction && multiplier && multiplier.mul(fraction).simplify(0.01);
 
   return (
     <>
-      {displayNumber &&
-        (inputType === MultiplyableInputTypes.FRACTION
+      {displayNumber
+        ? inputType === MultiplyableInputTypes.FRACTION
           ? displayNumber.simplify(0.0125).toFraction(true)
-          : displayNumber.round(3).toString())}
+          : displayNumber.round(3).toString()
+        : baseNumber}
     </>
   );
 }

--- a/websites/recipe-website/editor/cypress/e2e/new-recipe.cy.ts
+++ b/websites/recipe-website/editor/cypress/e2e/new-recipe.cy.ts
@@ -583,6 +583,40 @@ Have no number on three
         cy.findByText(`Have whitespace at the beginning and end`);
       });
 
+      it.only("should display pasted multiplyable numbers as their original format before multiplying", function () {
+        cy.findByRole("heading", { name: "New Recipe" });
+
+        const newRecipeTitle = "My New Recipe";
+
+        cy.findAllByLabelText("Name").first().clear();
+        cy.findAllByLabelText("Name").first().type(newRecipeTitle);
+
+        cy.findByText("Paste Ingredients").click();
+        cy.findByTitle("Ingredients Paste Area").type(
+          `
+- 20/10 cup flour
+- 1 cup water
+`,
+        );
+
+        cy.findByText("Import Ingredients").click();
+
+        cy.get('[name="ingredients[0].ingredient"]').should(
+          "have.value",
+          `<Multiplyable baseNumber="20/10" /> cup flour`,
+        );
+        cy.get('[name="ingredients[1].ingredient"]').should(
+          "have.value",
+          `<Multiplyable baseNumber="1" /> cup water`,
+        );
+        cy.findByText("Submit").click();
+
+        cy.findByRole("heading", { name: newRecipeTitle });
+
+        cy.findByText("20/10 cup flour");
+        cy.findByText("1 cup water");
+      });
+
       // Create tests focusing on individual edge cases
       it("should be able to paste ingredients with different indentation levels", function () {
         cy.findByRole("heading", { name: "New Recipe" });


### PR DESCRIPTION
This PR makes it so the number passed to `Multiplyable` will not be reformatted until it is multiplied. 
An easy example and the one that spurred this is imbalanced fractions: "80/20" would get simplified to "4" without any multiplication. This example serves no practical use on its own, but does help mitigate issues when accidentally importing numbers as multiplyable (e.g. "80/20 beef")- the original text will be readable before multiplying instead of botched all the time.

Before:

https://github.com/user-attachments/assets/6625310b-ea43-4138-a7c4-24db5ec6269f

After:

https://github.com/user-attachments/assets/f116204c-b7b9-4b51-a6e9-a5e6bd2f6fad
