### PR TITLE
Rewrite READMEs, fully rename to content-engine, add lint-staged scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,39 @@
-# Content Engine Workspace
+# Discontent
 
-This monorepo hosts a group of packages that establish and re-use patterns to create content-driven websites with custom graphical editors.
+A composable CMS system for building content-driven websites with custom graphical editors. All reusable packages are published under the `@discontent/` npm scope.
 
-The projects in [`packages`](packages) are libraries that could be published as reusable packages, and the ones in [`websites`](websites) are examples of concrete implementations using those packages.
+The projects in [`packages`](packages) are libraries that can be published as reusable packages, and the ones in [`websites`](websites) are concrete implementations built with those packages.
 
-Generally, a website made with these packages will span two projects: the editor and the export. The editor is a dynamic app that has serves as a custom-built CMS, and that CMS calls the export project to build a static website with that content. Having this editor/website pattern combines the accessibility of a dynamic graphical CMS with the effortless hosting of a static website.
+## Architecture
 
-Reusable packages in this repo aim to be composable, allowing any implementation full control over the process of creating content. For example, a website can check in with any authentication service that's compatible with NextJS before calling the functions from `@discontent/cms` to persist content to LMDB and the filesystem.
+Generally, a website built with Discontent spans two projects: the **editor** and the **export**. The editor is a dynamic Next.js app that serves as a custom-built CMS. When content changes, the editor calls the export project to rebuild a static website from that content. This pattern combines the accessibility of a graphical CMS with the simplicity of static site hosting.
 
-One standout in this monorepo is [`@discontent/next-static-image`](packages/next-static-image), which enables build-time optimization of dynamic images in a NextJS static export project with minimal API changes. This package may graduate into its own repo eventually, but the websites in this repo serve as its best test target currently.
+Reusable packages are composable — any implementation retains full control over the content pipeline. For example, a website can authenticate via any NextAuth-compatible provider before calling `@discontent/cms` to persist content to LMDB and the filesystem.
 
-The [Recipe Website](websites/recipe-website) project is the most complete implementation of a real-world project using the code in this monorepo, but more are planned in the future.
+## Packages
 
-# Running tests
+| Package                                                           | Description                                                                                                                               |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| [`@discontent/cms`](packages/cms)                                 | Core CMS engine: CRUD operations, LMDB indexing, git commits, filesystem utilities, and form parsing, all driven by a `ContentTypeConfig` |
+| [`@discontent/component-library`](packages/component-library)     | Shared React UI library: form inputs, display components, and shadcn/ui primitives                                                        |
+| [`@discontent/next-static-image`](packages/next-static-image)     | Build-time image optimization for Next.js static exports using `sharp`                                                                    |
+| [`@discontent/menus-collection`](packages/menus-collection)       | Content module for managing navigation menus with nested `MenuItem` entries                                                               |
+| [`@discontent/pages-collection`](packages/pages-collection)       | Content module for managing CMS pages with name, date, and markdown content                                                               |
+| [`@discontent/projects-collection`](packages/projects-collection) | Content module for managing portfolio projects with name, date, and markdown content                                                      |
 
-## E2E Tests (Cypress)
+## Websites
+
+| Website                                     | Description                                                                                |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [`recipe-website`](websites/recipe-website) | A recipe book with fractional ingredient quantities, full-text search, and a static export |
+| [`portfolio`](websites/portfolio)           | A project portfolio/book with NextAuth user-gating and a static export                     |
+| [`resume-builder`](websites/resume-builder) | A minimal CRUD app for building and managing tailored resumes, with PDF-print support      |
+
+The [Recipe Website](websites/recipe-website) is the most complete implementation and the primary test target for the packages.
+
+## Running Tests
+
+### E2E Tests (Cypress)
 
 End-to-end tests are available for the recipe editor. Tests can run against the dev server (`e2e-dev`) or an optimized production build (`e2e-start`). `e2e-dev` is useful for rapid iteration, while `e2e-start` is faster and closer to production.
 

--- a/lint-staged.write.config.mjs
+++ b/lint-staged.write.config.mjs
@@ -1,0 +1,6 @@
+const config = {
+  "*.{json,md,mdx,yml,yaml,css}": "prettier --write",
+  "*.{js,jsx,ts,tsx,mjs}": ["prettier --write", "eslint --fix"],
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "content-engine-workspace",
+  "name": "discontent-workspace",
   "version": "0.0.1",
   "description": "",
   "main": "index.js",
@@ -8,7 +8,9 @@
   },
   "scripts": {
     "prepare": "husky",
-    "test": "vitest"
+    "test": "vitest",
+    "lint:diff": "lint-staged",
+    "lint:diff:write": "lint-staged -c lint-staged.write.config.mjs"
   },
   "author": "",
   "license": "MIT",

--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -1,5 +1,81 @@
 # @discontent/cms
 
-The core CMS engine providing generic, reusable primitives for managing file-backed content. It provides CRUD operations, LMDB-based indexing, git commit integration, filesystem utilities, and form parsing — all driven by a `ContentTypeConfig` that consumers define to describe their specific content type.
+The core CMS engine providing generic, reusable primitives for managing file-backed content. All functionality is driven by a `ContentTypeConfig` that consumers define to describe their specific content type.
+
+## ContentTypeConfig
+
+`ContentTypeConfig<TData, TIndexValue, TKey>` is the central abstraction. It describes how a content type is stored, indexed, and referenced:
+
+```ts
+interface ContentTypeConfig<TData, TIndexValue, TKey extends Key> {
+  contentType: string; // identifier, e.g. "recipes"
+  dataDirectory: string; // subdirectory for data files
+  indexDirectory: string; // subdirectory for the LMDB index
+  dataFilename: string; // filename for each content item, e.g. "recipe.json"
+  buildIndexValue(data: TData): TIndexValue;
+  buildIndexKey(slug: string, data: TData): TKey;
+  createDefaultSlug?(data: TData): string;
+  uploadsDirectory?: string;
+  referencedBy?: ReferenceSpec[]; // other types that reference this one by slug
+}
+```
+
+## Sub-modules
+
+### `content/`
+
+Core CRUD operations and indexing.
+
+| Export                      | Description                                                                                                                       |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `createContent(options)`    | Creates a new content item on the filesystem and writes its index entry. Throws `SlugConflictError` if the slug is already taken. |
+| `updateContent(options)`    | Updates an existing content item. Handles slug renames, index key changes, and optional upload processing.                        |
+| `deleteContent(options)`    | Deletes a content item from the filesystem and removes its index entry.                                                           |
+| `readContentFile(options)`  | Reads and returns the data file for a single content item by slug.                                                                |
+| `readContentIndex(options)` | Reads paginated entries from the LMDB index. Returns `{ entries, total, more }`. Supports `limit`, `offset`, and `reverse`.       |
+| `rebuildIndex(options)`     | Scans all data files and rebuilds the LMDB index from scratch.                                                                    |
+
+All mutation functions accept an optional `author` and `commitMessage` to record a git commit after the change.
+
+### `fs/`
+
+Filesystem helpers.
+
+| Export                        | Description                                                                                                                            |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `getContentDirectory()`       | Returns the content directory path. Respects `CONTENT_DIRECTORY` env var; falls back to `test-content` in `TEST_MODE`, then `content`. |
+| `contentDirectory`            | Pre-resolved content directory path (evaluated at import time).                                                                        |
+| `collectFiles(dir, filename)` | Recursively collects all files with a given name under a directory.                                                                    |
+
+### `git/`
+
+Git integration.
+
+| Export                                                      | Description                                                                                         |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `commitChanges(contentDirectory, message, author?, paths?)` | Stages the given paths and creates a git commit. No-ops if the content directory is not a git repo. |
+| `directoryIsGitRepo(dir)`                                   | Returns `true` if the directory contains a `.git` folder.                                           |
+
+### `forms/`
+
+Form data parsing.
+
+| Export                            | Description                                                                                                                                                  |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `parseFormData(schema, formData)` | Validates a `FormData` object against a Zod schema, using lodash `set` for nested field assignment. Returns the parsed data or throws on validation failure. |
+
+### `hooks/`
+
+React hooks.
+
+| Export                 | Description                                                                     |
+| ---------------------- | ------------------------------------------------------------------------------- |
+| `useCurrentTimezone()` | Returns the browser's current IANA timezone string using `Intl.DateTimeFormat`. |
+
+## Key Types
+
+- **`ReferenceSpec`** — Describes a content type that references another by slug. Used by `updateContent` to automatically update references when a slug changes.
+- **`UploadSpec`** — Per-field upload specification: a `File`, a `fileImportUrl`, a `clearFile` flag, or an existing filename.
+- **`FileUploadData`** — Resolved upload data passed to custom `processUploads` callbacks.
 
 ## Part of [Discontent](https://github.com/rogermparent/discontent)

--- a/packages/cms/demo/app/layout.tsx
+++ b/packages/cms/demo/app/layout.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: "Content Engine Demo",
-  description: "Demo application for content-engine package",
+  title: "Discontent Demo",
+  description: "Demo application for the Discontent package",
 };
 
 export default function RootLayout({
@@ -30,7 +30,7 @@ export default function RootLayout({
         >
           <h1 style={{ margin: 0 }}>
             <Link href="/" style={{ textDecoration: "none", color: "inherit" }}>
-              Content Engine Demo
+              Discontent Demo
             </Link>
           </h1>
         </header>

--- a/packages/cms/demo/package.json
+++ b/packages/cms/demo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "content-engine-demo",
+  "name": "discontent-demo",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/packages/component-library/README.md
+++ b/packages/component-library/README.md
@@ -1,5 +1,48 @@
 # @discontent/component-library
 
-A shared React UI component library providing form inputs (text, markdown, image, video, date, duration, list, etc.), display components (Button, VideoPlayer, StickyVideoPlayer, Markdown renderer), and shadcn/ui primitives. Consumed by website frontends across the monorepo.
+A shared React UI component library providing form inputs, display components, and shadcn/ui primitives. Consumed by website frontends across the Discontent monorepo.
+
+## Form Inputs (`components/Form/inputs/`)
+
+Each input is a React component intended for use inside a Next.js Server Action form.
+
+| Component                        | Description                                           |
+| -------------------------------- | ----------------------------------------------------- |
+| `TextInput`                      | Single-line text field                                |
+| `TextAreaInput`                  | Multi-line text area                                  |
+| `PasswordInput`                  | Password field with masked input                      |
+| `DateInput`                      | Date picker (date only)                               |
+| `DateTimeInput`                  | Date and time picker with timezone support            |
+| `SelectInput`                    | Dropdown select                                       |
+| `CheckboxInput`                  | Checkbox toggle                                       |
+| `FileInput`                      | Generic file upload                                   |
+| `ImageInput`                     | Image upload with preview and clear button            |
+| `VideoInput`                     | Video field with URL or file upload mode toggle       |
+| `DurationNumberInput`            | Numeric input for time durations                      |
+| `MarkdownInput`                  | Markdown editor with edit/preview tab toggle          |
+| `InlineMarkdownInput`            | Inline variant of the markdown editor                 |
+| `KeyListAction` / `KeyListState` | Dynamic ordered list input (add/remove/reorder items) |
+
+Form utilities in `components/Form/` include `Label`, `FieldWrapper`, and the shared `baseInputStyle` class string.
+
+## Display Components
+
+| Component           | Description                                                               |
+| ------------------- | ------------------------------------------------------------------------- |
+| `Button`            | Styled button wrapping the shadcn/ui `Button` primitive                   |
+| `SubmitButton`      | Button that reflects form pending state                                   |
+| `StyledMarkdown`    | Markdown renderer using `markdown-to-jsx` with Next.js `Link` integration |
+| `VideoPlayer`       | `react-player` wrapper with a React context for shared player state       |
+| `StickyVideoPlayer` | `VideoPlayer` with a mode toggle for sticky/floating positioning          |
+
+## UI Primitives (`ui/`)
+
+shadcn/ui components including `button`, `dialog`, and `slot`. Styled with Tailwind CSS and `tw-animate-css`.
+
+## Utilities (`lib/`)
+
+| Export          | Description                                                             |
+| --------------- | ----------------------------------------------------------------------- |
+| `cn(...inputs)` | Combines `clsx` and `tailwind-merge` for conditional class name merging |
 
 ## Part of [Discontent](https://github.com/rogermparent/discontent)

--- a/packages/menus-collection/README.md
+++ b/packages/menus-collection/README.md
@@ -1,5 +1,61 @@
 # @discontent/menus-collection
 
-A content module for managing navigation menus. Provides controller actions, form parsing, data reading, and React components for a `Menu` type with nested `MenuItem` entries.
+A content module for managing navigation menus. Provides a `ContentTypeConfig`-driven controller with CRUD server actions, form data parsing, and React components for creating and displaying menus with nested `MenuItem` entries.
+
+## Types
+
+```ts
+interface MenuItem {
+  name: string;
+  href: string;
+  children?: MenuItem[];
+}
+
+interface Menu {
+  items?: MenuItem[];
+}
+```
+
+## Controller (`controller/`)
+
+### Filesystem utilities
+
+| Export                          | Description                                 |
+| ------------------------------- | ------------------------------------------- |
+| `menusBaseDirectory`            | Absolute path to the menus data directory   |
+| `getMenuDirectory(slug)`        | Path to a specific menu's directory         |
+| `getMenuFilePath(slug)`         | Path to a specific menu's JSON data file    |
+| `getMenuUploadsDirectory(slug)` | Path to a specific menu's uploads directory |
+
+### Data
+
+| Export                | Description                                          |
+| --------------------- | ---------------------------------------------------- |
+| `getMenuBySlug(slug)` | Reads and returns the `Menu` data for the given slug |
+
+### Server actions
+
+| Export                 | Description                                                    |
+| ---------------------- | -------------------------------------------------------------- |
+| `updateMenu(formData)` | Persists changes to an existing menu and triggers revalidation |
+| `deleteMenu(slug)`     | Deletes a menu's directory and index entry                     |
+
+### Utilities
+
+| Export                    | Description                                 |
+| ------------------------- | ------------------------------------------- |
+| `createSlug(data)`        | Derives a default slug from the menu name   |
+| `parseFormData(formData)` | Parses and validates a menu form submission |
+
+## Components (`components/`)
+
+| Component        | Description                                                                 |
+| ---------------- | --------------------------------------------------------------------------- |
+| `MenuForm`       | Base form wrapper for menu data                                             |
+| `MenuFields`     | Field inputs for menu name and items                                        |
+| `ItemsListInput` | Dynamic list input for adding/removing/reordering nested `MenuItem` entries |
+| `CreateMenuForm` | Standalone form for creating a new menu                                     |
+| `UpdateMenuForm` | Standalone form for editing an existing menu                                |
+| `MenuView`       | Display component that renders a menu's name and item list                  |
 
 ## Part of [Discontent](https://github.com/rogermparent/discontent)

--- a/packages/next-static-image/README.md
+++ b/packages/next-static-image/README.md
@@ -1,5 +1,42 @@
 # @discontent/next-static-image
 
-A Next.js utility that pre-processes local images at build/render time using `sharp`. It resizes and converts images to WebP at multiple widths/qualities, writing them to a local output directory, and returns the standard Next.js `getImageProps` result pointing to those generated files.
+A Next.js utility that solves a gap in the static export workflow: Next.js cannot optimize dynamically-referenced local images at build time the way it can with statically-imported images. This package fills that gap by pre-processing images with `sharp` at render/build time, generating responsive WebP variants and returning standard `getImageProps`-compatible props.
+
+## How It Works
+
+1. At render time, `getStaticImageProps` receives the source image path and an output directory.
+2. It enqueues resizes at each responsive width, converting each variant to WebP with a configurable quality.
+3. Resized files are written to the local output directory (cached by modification time so they are only regenerated when the source changes).
+4. It returns the standard Next.js `getImageProps` result with the loader pointing at the generated files — no changes needed at the call site compared to using the built-in Next.js image optimization.
+
+## API
+
+### `getStaticImageProps(transform, imageProps)`
+
+Main entry point for images that need local transformation.
+
+```ts
+const { props } = await getStaticImageProps(
+  {
+    srcPath: "/absolute/path/to/source/image.jpg",
+    localOutputDirectory: "./public/image",
+  },
+  {
+    src: "/relative/url/for/image.jpg",
+    alt: "Description",
+    sizes: "(max-width: 768px) 100vw, 50vw",
+  },
+);
+```
+
+Returns `StaticImageProps` containing `props` ready to spread onto a `<img>` element.
+
+### `getPureStaticImageProps(imageProps)` / `pureLoader`
+
+For cases where transformation is skipped (e.g. during development or for already-optimized images). `pureLoader` is a Next.js-compatible image loader that constructs responsive URLs without running `sharp`.
+
+## Dependencies
+
+Requires `sharp` as a peer dependency. `sharp` is listed as a direct dependency in packages that use this utility.
 
 ## Part of [Discontent](https://github.com/rogermparent/discontent)

--- a/packages/pages-collection/README.md
+++ b/packages/pages-collection/README.md
@@ -1,5 +1,56 @@
 # @discontent/pages-collection
 
-A content module for managing generic CMS pages with name, date, and markdown content. Provides CRUD actions, index reading, form parsing, and React form/view components.
+A content module for managing generic CMS pages. Provides a `ContentTypeConfig`-driven controller with CRUD server actions, form data parsing, and React components for creating, editing, and viewing pages.
+
+## Types
+
+```ts
+interface Page {
+  name: string;
+  date: number; // Unix timestamp
+  content: string; // Markdown body
+}
+```
+
+## Controller (`controller/`)
+
+### Filesystem utilities
+
+| Export                          | Description                                 |
+| ------------------------------- | ------------------------------------------- |
+| `pagesBaseDirectory`            | Absolute path to the pages data directory   |
+| `getPageDirectory(slug)`        | Path to a specific page's directory         |
+| `getPageFilePath(slug)`         | Path to a specific page's JSON data file    |
+| `getPageUploadsDirectory(slug)` | Path to a specific page's uploads directory |
+
+### Data
+
+| Export                | Description                                          |
+| --------------------- | ---------------------------------------------------- |
+| `getPageBySlug(slug)` | Reads and returns the `Page` data for the given slug |
+
+### Server actions
+
+| Export                 | Description                                                    |
+| ---------------------- | -------------------------------------------------------------- |
+| `updatePage(formData)` | Persists changes to an existing page and triggers revalidation |
+| `deletePage(slug)`     | Deletes a page's directory and index entry                     |
+
+### Utilities
+
+| Export                    | Description                                 |
+| ------------------------- | ------------------------------------------- |
+| `createSlug(data)`        | Derives a default slug from the page name   |
+| `parseFormData(formData)` | Parses and validates a page form submission |
+
+## Components (`components/`)
+
+| Component        | Description                                                       |
+| ---------------- | ----------------------------------------------------------------- |
+| `PageForm`       | Base form wrapper for page data                                   |
+| `PageFields`     | Field inputs for name, date, and markdown content                 |
+| `CreatePageForm` | Standalone form for creating a new page                           |
+| `UpdatePageForm` | Standalone form for editing an existing page                      |
+| `PageView`       | Display component that renders the page name and markdown content |
 
 ## Part of [Discontent](https://github.com/rogermparent/discontent)

--- a/packages/projects-collection/README.md
+++ b/packages/projects-collection/README.md
@@ -1,5 +1,56 @@
 # @discontent/projects-collection
 
-A content module for managing projects with name, date, and markdown content. Provides CRUD actions, index reading, form parsing, and React form/view components.
+A content module for managing portfolio projects. Provides a `ContentTypeConfig`-driven controller with CRUD server actions, form data parsing, and React components for creating, editing, and viewing projects.
+
+## Types
+
+```ts
+interface Project {
+  name: string;
+  date: number; // Unix timestamp
+  content: string; // Markdown description
+}
+```
+
+## Controller (`controller/`)
+
+### Filesystem utilities
+
+| Export                             | Description                                    |
+| ---------------------------------- | ---------------------------------------------- |
+| `projectsBaseDirectory`            | Absolute path to the projects data directory   |
+| `getProjectDirectory(slug)`        | Path to a specific project's directory         |
+| `getProjectFilePath(slug)`         | Path to a specific project's JSON data file    |
+| `getProjectUploadsDirectory(slug)` | Path to a specific project's uploads directory |
+
+### Data
+
+| Export                   | Description                                             |
+| ------------------------ | ------------------------------------------------------- |
+| `getProjectBySlug(slug)` | Reads and returns the `Project` data for the given slug |
+
+### Server actions
+
+| Export                    | Description                                                       |
+| ------------------------- | ----------------------------------------------------------------- |
+| `updateProject(formData)` | Persists changes to an existing project and triggers revalidation |
+| `deleteProject(slug)`     | Deletes a project's directory and index entry                     |
+
+### Utilities
+
+| Export                    | Description                                    |
+| ------------------------- | ---------------------------------------------- |
+| `createSlug(data)`        | Derives a default slug from the project name   |
+| `parseFormData(formData)` | Parses and validates a project form submission |
+
+## Components (`components/`)
+
+| Component           | Description                                                              |
+| ------------------- | ------------------------------------------------------------------------ |
+| `ProjectForm`       | Base form wrapper for project data                                       |
+| `ProjectFields`     | Field inputs for name, date, and markdown content                        |
+| `CreateProjectForm` | Standalone form for creating a new project                               |
+| `UpdateProjectForm` | Standalone form for editing an existing project                          |
+| `ProjectView`       | Display component that renders the project name and markdown description |
 
 ## Part of [Discontent](https://github.com/rogermparent/discontent)

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -14,7 +14,7 @@ export default defineConfig({
       "next/cache": resolve("test", "stub_cache.js"),
       "next/navigation": resolve("test", "stub_navigation.js"),
       "@/auth": resolve("test", "stub_auth.js"),
-      "content-engine/fs/getContentDirectory": resolve(
+      "discontent/fs/getContentDirectory": resolve(
         "test",
         "stub_content_directory.js",
       ),

--- a/websites/portfolio/README.md
+++ b/websites/portfolio/README.md
@@ -1,8 +1,14 @@
 # Portfolio
 
-This project is a proof-of-concept application that serves the purpose of a project book, useful both privately and shared on the Internet. The editor has basic user-gating with NextAuth, mostly just to show off the functionality but can also be improved to provide decent security for an editor server that can be accessed over a network.
+A project portfolio/book application built on Discontent. The editor has basic user-gating with NextAuth and the export generates a fully static site.
 
-The primary data source is a tree of directories in the Content Directory, which by default is named `content` and located at the root of the project.
+## Sub-packages
+
+| Package                                | Description                                                                                                                                                                                                                                                                       |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `portfolio-website-common` (`common/`) | Shared controllers, components, and utilities used by both the editor and export. Includes the homepage controller and components for displaying projects and pages, using `@discontent/projects-collection`, `@discontent/pages-collection`, and `@discontent/menus-collection`. |
+| `portfolio-website-editor` (`editor/`) | The Next.js CMS editor app. Handles project and page creation and editing, user authentication, and triggers static rebuilds.                                                                                                                                                     |
+| `portfolio-website-export` (`export/`) | The Next.js static export app. Consumes the same content directory as the editor and generates an optimized static site with responsive images via `@discontent/next-static-image`.                                                                                               |
 
 ## Getting Started
 

--- a/websites/recipe-website/README.md
+++ b/websites/recipe-website/README.md
@@ -1,8 +1,14 @@
 # Recipe Website
 
-This project is a proof-of-concept application that serves the purpose of a recipe book, useful both privately and shared on the Internet. The editor has basic user-gating with NextAuth, mostly just to show off the functionality but can also be improved to provide decent security for an editor server that can be accessed over a network.
+A recipe book application built on Discontent. The editor has basic user-gating with NextAuth and the export generates a fully static site suitable for deployment on any static host (Netlify is supported out of the box).
 
-The primary data source is a tree of directories in the Content Directory, which by default is named `content` and located at the root of the project.
+## Sub-packages
+
+| Package                             | Description                                                                                                                                                                                                                                                                                              |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `recipe-website-common` (`common/`) | Shared controllers, components, and utilities used by both the editor and export. Includes the recipe `ContentTypeConfig`, ingredient parsing with fractional quantities (`fraction.js` / `format-quantity`), FlexSearch-based full-text search, and menu navigation via `@discontent/menus-collection`. |
+| `recipe-editor` (`editor/`)         | The Next.js CMS editor app. Handles recipe creation and editing, image and video uploads, user authentication, and triggers static rebuilds.                                                                                                                                                             |
+| `recipe-website` (`export/`)        | The Next.js static export app. Consumes the same content directory as the editor and generates an optimized static site with responsive images via `@discontent/next-static-image`. Deployable to Netlify with `pnpm deploy`.                                                                            |
 
 ## Getting Started
 
@@ -60,22 +66,24 @@ pnpm e2e-start          # Interactive (Cypress UI)
 pnpm e2e-start:headless # Headless (for CI)
 ```
 
+See [editor/cypress/README.md](editor/cypress/README.md) for full details about the test suite, fixtures, and custom commands.
+
 ## Docker
 
-The root of the monorepo is equipped with a basic Dockerfile which enables running this editor.
+The root of the monorepo includes a basic Dockerfile for running the editor.
 
-Use the following command in the root of this repo to build a Docker image:
-
-```bash
-docker build -t content-engine-recipe-website .
-```
-
-Now you can run the image:
+Build the image:
 
 ```bash
-docker run --name recipe-editor -p 3000:3000 content-engine-recipe-website:latest
+docker build -t discontent-recipe-website .
 ```
 
-And now you should be able to access the editor at `localhost:3000` with the baked-in account `admin@example.com`/`password`
+Run the image:
 
-This is a very basic container setup and currently cannot be recommended for a production deploy.
+```bash
+docker run --name recipe-editor -p 3000:3000 discontent-recipe-website:latest
+```
+
+The editor will be available at `localhost:3000` with the baked-in account `admin@example.com` / `password`.
+
+This is a basic container setup and is not recommended for production deployment.

--- a/websites/resume-builder/README.md
+++ b/websites/resume-builder/README.md
@@ -1,8 +1,51 @@
 # Next Resume Builder
 
-This project is a minimal web app which provides a simple CRUD resume app, along with a "copy" function that serves as the primary workflow for quickly creating a resume similar but tailored to the individual job.
+A minimal web app for building and managing tailored resumes, built on Discontent. The primary workflow is to create a base resume and then use the **copy** function to quickly produce variations targeted at individual job applications.
 
-Currently, the site is built to display the resume as a styled page which can be printed as a PDF for use on job sites.
+Resumes are displayed as styled pages that can be printed to PDF for use on job sites.
+
+## Getting Started
+
+Install package dependencies from the root:
+
+```bash
+pnpm install
+```
+
+Run the development server:
+
+```bash
+pnpm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) to use the app.
+
+## Resume Data Model
+
+Each resume stores the following fields:
+
+| Field        | Description                            |
+| ------------ | -------------------------------------- |
+| `job`        | Target job title                       |
+| `company`    | Target company name                    |
+| `name`       | Your name                              |
+| `phone`      | Phone number                           |
+| `email`      | Email address                          |
+| `address`    | Mailing address                        |
+| `github`     | GitHub profile URL                     |
+| `linkedin`   | LinkedIn profile URL                   |
+| `website`    | Personal website URL                   |
+| `skills`     | Array of skill strings                 |
+| `education`  | Array of education entries             |
+| `experience` | Array of work experience entries       |
+| `projects`   | Array of project entries               |
+| `date`       | Creation timestamp (used as index key) |
+
+Resumes are indexed by `[date, slug]` in LMDB for fast listing.
+
+## Copy Workflow
+
+The copy function duplicates an existing resume as a starting point for a new variation. This is the intended workflow for quickly tailoring a resume to a specific job without starting from scratch.
 
 ## Test Suite
 


### PR DESCRIPTION
* Replace content-engine with discontent across the repo
* Have Claude Sonnet write basic READMEs for all packages
* Add npm scripts at the workspace level for `lint-staged` including an alternate config that runs `prettier --write` and `eslint --fix`